### PR TITLE
chore(spec): update OpenAPI spec

### DIFF
--- a/specs/openapi-metadata.json
+++ b/specs/openapi-metadata.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2025-09-07T07:23:35.485Z",
+  "fetchedAt": "2025-09-09T07:25:37.872Z",
   "apiVersion": "3.0.0",
   "checksum": "6325f2902644714be596ec3f919414cccc8afe04ab301e28d3cd73706f56ef3c",
   "endpoint": "https://api.kadoa.com/openapi"


### PR DESCRIPTION
This PR updates `specs/openapi.json` and `specs/openapi-metadata.json` with the latest version from `https://api.kadoa.com/openapi`.

If merged, the spec fingerprint workflow will trigger SDK releases if needed.