### PR TITLE
chore(spec): update OpenAPI spec

### DIFF
--- a/specs/openapi-metadata.json
+++ b/specs/openapi-metadata.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2025-09-09T09:29:35.773Z",
+  "fetchedAt": "2025-09-10T07:24:51.189Z",
   "apiVersion": "3.0.0",
   "checksum": "b7e6a22703921d734d66eacd6703b41ff0fffcffd0d5dd9bd5c7dae3527294db",
   "endpoint": "https://api.kadoa.com/openapi"


### PR DESCRIPTION
This PR updates `specs/openapi.json` and `specs/openapi-metadata.json` with the latest version from `https://api.kadoa.com/openapi`.

If merged, the spec fingerprint workflow will trigger SDK releases if needed.