### PR TITLE
chore(spec): update OpenAPI spec

### DIFF
--- a/specs/openapi-metadata.json
+++ b/specs/openapi-metadata.json
@@ -1,6 +1,6 @@
 {
-  "fetchedAt": "2025-10-03T15:50:47.484Z",
+  "fetchedAt": "2025-10-04T07:22:51.122Z",
   "apiVersion": "3.0.0",
-  "checksum": "7e41aaaaec4784a273e41690051a8f05231785f1ee98fc8e961de7c51595431a",
+  "checksum": "5ede7bfd12a4296e16c6a46effd8d8a9d04c82550b53ec9fd6969ca1f5a1ab03",
   "endpoint": "https://api.kadoa.com/openapi"
 }

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -14676,6 +14676,7 @@
             "description": "List of URLs to scrape"
           },
           "navigationMode": {
+            "default": "single-page",
             "type": "string",
             "enum": [
               "single-page",
@@ -14773,7 +14774,6 @@
         },
         "required": [
           "urls",
-          "navigationMode",
           "schemaId"
         ],
         "title": "CreateWorkflowWithSchemaBody",
@@ -14792,6 +14792,7 @@
             "description": "List of URLs to scrape"
           },
           "navigationMode": {
+            "default": "single-page",
             "type": "string",
             "enum": [
               "single-page",
@@ -14912,7 +14913,6 @@
         },
         "required": [
           "urls",
-          "navigationMode",
           "entity",
           "fields"
         ],


### PR DESCRIPTION
This PR updates `specs/openapi.json` and `specs/openapi-metadata.json` with the latest version from `https://api.kadoa.com/openapi`.

If merged, the spec fingerprint workflow will trigger SDK releases if needed.