### PR TITLE
fix(node-sdk): align variable data type enum to ui types

### DIFF
--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -22019,9 +22019,9 @@
         "type": "string",
         "enum": [
           "STRING",
-          "NUMBER",
-          "BOOLEAN",
-          "JSON"
+          "SECRET",
+          "OBJECT",
+          "ARRAY"
         ],
         "title": "VariableDataType",
         "description": "The data type of the variable value"


### PR DESCRIPTION
Updates OpenAPI spec to match the enum change made in kadoa-backend#7714. Changes VariableDataType from STRING/NUMBER/BOOLEAN/JSON to STRING/SECRET/OBJECT/ARRAY to match the dashboard UI types.

Generated client code in sdks/node/src/generated is regenerated from the spec (gitignored).

Refs: KAD-6266