### PR TITLE
fix: trigger SDK release for extraction changes

### DIFF
--- a/sdks/node/src/domains/extraction/services/extraction-builder.service.ts
+++ b/sdks/node/src/domains/extraction/services/extraction-builder.service.ts
@@ -450,6 +450,8 @@ export class ExtractionBuilderService {
     workflowId: string,
     input: RunWorkflowOptions,
   ) {
+    // Some agentic workflows already have an active job by the time create()
+    // returns, so reuse that run instead of issuing a duplicate /run request.
     const currentJob = await this.findActiveWorkflowJob(workflowId);
     if (currentJob) {
       debug("Reusing active workflow job: %O", currentJob);

--- a/sdks/python/kadoa_sdk/extraction/services/extraction_builder_service.py
+++ b/sdks/python/kadoa_sdk/extraction/services/extraction_builder_service.py
@@ -702,6 +702,9 @@ class ExtractionBuilderService:
         workflow_id: str,
         options: Optional[RunWorkflowOptions] = None,
     ) -> str:
+        # Some agentic workflows already have an active job by the time
+        # create() returns, so reuse that run instead of issuing a duplicate
+        # /run request.
         existing_job_id = self._find_active_workflow_job(workflow_id)
         if existing_job_id:
             return existing_job_id


### PR DESCRIPTION
This follow-up PR gives Release Please a parseable `fix:` merge title so the extraction changes from #264 can be released.

It also documents in both SDK builders why `run()` and `submit()` reuse an already-started job after `create()`.

Refs KAD-6352.