### PR TITLE
feat(node-sdk): align templates with backend v1

### DIFF
--- a/sdks/node/src/domains/templates/index.ts
+++ b/sdks/node/src/domains/templates/index.ts
@@ -1,10 +1,6 @@
 export type {
-  ApplyTemplateUpdateRequest,
-  ApplyTemplateUpdateResult,
   CreateTemplateRequest,
   CreateTemplateVersionRequest,
-  LinkWorkflowsRequest,
-  LinkWorkflowsResult,
   SaveFromWorkflowRequest,
   SaveFromWorkflowResult,
   Template,
@@ -12,9 +8,6 @@ export type {
   TemplateListItem,
   TemplateSchema,
   TemplateVersion,
-  TemplateWorkflow,
-  UnlinkWorkflowsRequest,
-  UnlinkWorkflowsResult,
   UpdateTemplateRequest,
 } from "./templates.acl";
 

--- a/sdks/node/src/domains/templates/templates.acl.ts
+++ b/sdks/node/src/domains/templates/templates.acl.ts
@@ -52,7 +52,13 @@ export type UnlinkWorkflowsRequest = GeneratedUnlinkWorkflowsBody;
 
 export type ApplyTemplateUpdateRequest = GeneratedApplyTemplateUpdateBody;
 
-export type SaveFromWorkflowRequest = GeneratedSaveFromWorkflowBody;
+export type SaveFromWorkflowRequest = GeneratedSaveFromWorkflowBody & {
+  /**
+   * Which parts of the workflow config to include in the template.
+   * Defaults to all parts when omitted. Rejects empty array with 400.
+   */
+  includeParts?: ("prompt" | "schema" | "notifications")[];
+};
 
 // ========================================
 // Response Types

--- a/sdks/node/src/domains/templates/templates.acl.ts
+++ b/sdks/node/src/domains/templates/templates.acl.ts
@@ -37,7 +37,7 @@ export type CreateTemplateRequest = GeneratedCreateTemplateBody;
 
 export type UpdateTemplateRequest = GeneratedUpdateTemplateBody;
 
-export type CreateTemplateVersionRequest = GeneratedCreateTemplateVersionBody;
+export type CreateTemplateVersionRequest = Omit<GeneratedCreateTemplateVersionBody, "dataValidation">;
 
 export type SaveFromWorkflowRequest = GeneratedSaveFromWorkflowBody & {
   /**

--- a/sdks/node/src/domains/templates/templates.acl.ts
+++ b/sdks/node/src/domains/templates/templates.acl.ts
@@ -9,25 +9,18 @@ import {
   TemplatesApi,
 
   // Request types
-  type ApplyTemplateUpdateBody as GeneratedApplyTemplateUpdateBody,
   type CreateTemplateBody as GeneratedCreateTemplateBody,
   type CreateTemplateVersionBody as GeneratedCreateTemplateVersionBody,
-  type LinkWorkflowsBody as GeneratedLinkWorkflowsBody,
   type SaveFromWorkflowBody as GeneratedSaveFromWorkflowBody,
-  type UnlinkWorkflowsBody as GeneratedUnlinkWorkflowsBody,
   type UpdateTemplateBody as GeneratedUpdateTemplateBody,
 
   // Response types
-  type ApplyTemplateUpdateResponse as GeneratedApplyTemplateUpdateResponse,
-  type LinkWorkflowsResponse as GeneratedLinkWorkflowsResponse,
   type SaveFromWorkflowResponseData as GeneratedSaveFromWorkflowResult,
   type TemplateCreatedResponseData as GeneratedTemplate,
   type TemplateDetailResponseBodyData as GeneratedTemplateDetail,
   type TemplateResponse as GeneratedTemplateListItem,
   type TemplateSchemasResponseDataInner as GeneratedTemplateSchema,
   type TemplateVersionCreatedResponseData as GeneratedTemplateVersion,
-  type TemplateWorkflowsResponseDataInner as GeneratedTemplateWorkflow,
-  type UnlinkWorkflowsResponse as GeneratedUnlinkWorkflowsResponse,
 } from "../../generated";
 
 // ========================================
@@ -45,12 +38,6 @@ export type CreateTemplateRequest = GeneratedCreateTemplateBody;
 export type UpdateTemplateRequest = GeneratedUpdateTemplateBody;
 
 export type CreateTemplateVersionRequest = GeneratedCreateTemplateVersionBody;
-
-export type LinkWorkflowsRequest = GeneratedLinkWorkflowsBody;
-
-export type UnlinkWorkflowsRequest = GeneratedUnlinkWorkflowsBody;
-
-export type ApplyTemplateUpdateRequest = GeneratedApplyTemplateUpdateBody;
 
 export type SaveFromWorkflowRequest = GeneratedSaveFromWorkflowBody & {
   /**
@@ -73,13 +60,5 @@ export type TemplateDetail = GeneratedTemplateDetail;
 export type TemplateVersion = GeneratedTemplateVersion;
 
 export type TemplateSchema = GeneratedTemplateSchema;
-
-export type TemplateWorkflow = GeneratedTemplateWorkflow;
-
-export type LinkWorkflowsResult = GeneratedLinkWorkflowsResponse;
-
-export type UnlinkWorkflowsResult = GeneratedUnlinkWorkflowsResponse;
-
-export type ApplyTemplateUpdateResult = GeneratedApplyTemplateUpdateResponse;
 
 export type SaveFromWorkflowResult = GeneratedSaveFromWorkflowResult;

--- a/sdks/node/src/domains/templates/templates.service.ts
+++ b/sdks/node/src/domains/templates/templates.service.ts
@@ -6,12 +6,8 @@ import {
 } from "../../runtime/exceptions/base.exception";
 import { logger } from "../../runtime/logger";
 import type {
-  ApplyTemplateUpdateRequest,
-  ApplyTemplateUpdateResult,
   CreateTemplateRequest,
   CreateTemplateVersionRequest,
-  LinkWorkflowsRequest,
-  LinkWorkflowsResult,
   SaveFromWorkflowRequest,
   SaveFromWorkflowResult,
   Template,
@@ -19,9 +15,6 @@ import type {
   TemplateListItem,
   TemplateSchema,
   TemplateVersion,
-  TemplateWorkflow,
-  UnlinkWorkflowsRequest,
-  UnlinkWorkflowsResult,
   UpdateTemplateRequest,
 } from "./templates.acl";
 
@@ -175,70 +168,6 @@ export class TemplatesService {
     });
 
     return response.data.data ?? [];
-  }
-
-  /**
-   * List workflows linked to a template.
-   */
-  async listWorkflows(templateId: string): Promise<TemplateWorkflow[]> {
-    debug("Listing workflows for template: %s", templateId);
-
-    const response = await this.templatesApi.v4TemplatesTemplateIdWorkflowsGet({
-      templateId,
-    });
-
-    return response.data.data ?? [];
-  }
-
-  /**
-   * Link workflows to a template.
-   */
-  async linkWorkflows(
-    templateId: string,
-    body: LinkWorkflowsRequest,
-  ): Promise<LinkWorkflowsResult> {
-    debug("Linking %d workflows to template: %s", body.workflowIds.length, templateId);
-
-    const response = await this.templatesApi.v4TemplatesTemplateIdLinkPost({
-      templateId,
-      linkWorkflowsBody: body,
-    });
-
-    return response.data;
-  }
-
-  /**
-   * Unlink workflows from a template.
-   */
-  async unlinkWorkflows(
-    templateId: string,
-    body: UnlinkWorkflowsRequest,
-  ): Promise<UnlinkWorkflowsResult> {
-    debug("Unlinking %d workflows from template: %s", body.workflowIds.length, templateId);
-
-    const response = await this.templatesApi.v4TemplatesTemplateIdUnlinkPost({
-      templateId,
-      unlinkWorkflowsBody: body,
-    });
-
-    return response.data;
-  }
-
-  /**
-   * Apply a template version update to specific workflows.
-   */
-  async applyUpdate(
-    templateId: string,
-    body: ApplyTemplateUpdateRequest,
-  ): Promise<ApplyTemplateUpdateResult> {
-    debug("Applying version %d to %d workflows for template: %s", body.targetVersion, body.workflowIds.length, templateId);
-
-    const response = await this.templatesApi.v4TemplatesTemplateIdApplyPost({
-      templateId,
-      applyTemplateUpdateBody: body,
-    });
-
-    return response.data;
   }
 
   /**

--- a/sdks/node/test/e2e/templates.test.ts
+++ b/sdks/node/test/e2e/templates.test.ts
@@ -105,22 +105,6 @@ describe("Templates", () => {
       { timeout: 60000 },
     );
 
-    test(
-      "should list workflows for a template",
-      async () => {
-        const template = await client.template.create({
-          name: `test-workflows-${Date.now()}`,
-        });
-
-        try {
-          const workflows = await client.template.listWorkflows(template.id);
-          expect(Array.isArray(workflows)).toBe(true);
-        } finally {
-          await client.template.delete(template.id);
-        }
-      },
-      { timeout: 60000 },
-    );
   });
 
   describe("Destructive Operations", () => {


### PR DESCRIPTION
## Summary

- **KAD-6442**: Add `includeParts` parameter to `SaveFromWorkflowRequest` — backend already supports selective part inclusion (prompt, schema, notifications)
- **KAD-6443**: Remove `linkWorkflows()`, `unlinkWorkflows()`, `applyUpdate()`, `listWorkflows()` — backend returns 501 on all four (templates are creation blueprints only in v1)
- **KAD-6444**: Remove `dataValidation` from `CreateTemplateVersionRequest` — backend dropped data validation support

All changes in the domain ACL layer only. Generated code untouched.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` passes
- [x] No removed symbols remain in `src/domains/`
- [ ] e2e tests pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)