### PR TITLE
fix(node-sdk): allow underscores in schema field names (KAD-6594)

### DIFF
--- a/sdks/node/src/domains/schemas/schema-builder.ts
+++ b/sdks/node/src/domains/schemas/schema-builder.ts
@@ -99,7 +99,7 @@ export interface FieldOptions {
  * Builder for defining custom schemas with fields
  */
 export class SchemaBuilder {
-  private static readonly FIELD_NAME_PATTERN = /^[A-Za-z0-9]+$/;
+  private static readonly FIELD_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]*$/;
   private static readonly TYPES_REQUIRING_EXAMPLE: DataType[] = [
     "STRING",
     "IMAGE",
@@ -136,7 +136,7 @@ export class SchemaBuilder {
 
   /**
    * Add a structured field to the schema
-   * @param name - Field name (alphanumeric only)
+   * @param name - Field name (must start with a letter; letters, digits, and underscores allowed)
    * @param description - Field description
    * @param dataType - Data type (STRING, NUMBER, BOOLEAN, etc.)
    * @param options - Field configuration (example required for STRING, IMAGE, LINK, OBJECT, ARRAY)
@@ -149,7 +149,7 @@ export class SchemaBuilder {
   ): this;
   /**
    * Add a structured field to the schema
-   * @param name - Field name (alphanumeric only)
+   * @param name - Field name (must start with a letter; letters, digits, and underscores allowed)
    * @param description - Field description
    * @param dataType - Data type (STRING, NUMBER, BOOLEAN, etc.)
    * @param options - Optional field configuration
@@ -190,7 +190,7 @@ export class SchemaBuilder {
 
   /**
    * Add a classification field to categorize content
-   * @param name - Field name (alphanumeric only)
+   * @param name - Field name (must start with a letter; letters, digits, and underscores allowed)
    * @param description - Field description
    * @param categories - Array of category definitions
    */
@@ -253,10 +253,10 @@ export class SchemaBuilder {
   private validateFieldName(name: string) {
     if (!SchemaBuilder.FIELD_NAME_PATTERN.test(name)) {
       throw new KadoaSdkException(
-        `Field name "${name}" must be alphanumeric only (no underscores or special characters)`,
+        `Field name "${name}" must start with a letter and contain only letters, digits, and underscores`,
         {
           code: "VALIDATION_ERROR",
-          details: { name, pattern: "^[A-Za-z0-9]+$" },
+          details: { name, pattern: "^[A-Za-z][A-Za-z0-9_]*$" },
         },
       );
     }

--- a/sdks/node/test/unit/schema-builder.test.ts
+++ b/sdks/node/test/unit/schema-builder.test.ts
@@ -64,6 +64,30 @@ describe("SchemaBuilder", () => {
           .field("inStock", "In Stock", "BOOLEAN");
       }).not.toThrow();
     });
+
+    test("allows underscores in field names", () => {
+      expect(() => {
+        new SchemaBuilder()
+          .entity("Company")
+          .field("company_name", "Company name", "STRING", { example: "Acme" });
+      }).not.toThrow();
+    });
+
+    test("rejects field names starting with a digit", () => {
+      expect(() => {
+        new SchemaBuilder()
+          .entity("Product")
+          .field("1title", "Title", "STRING", { example: "Example" });
+      }).toThrow(KadoaSdkException);
+    });
+
+    test("rejects field names with special characters", () => {
+      expect(() => {
+        new SchemaBuilder()
+          .entity("Product")
+          .field("title-name", "Title", "STRING", { example: "Example" });
+      }).toThrow(KadoaSdkException);
+    });
   });
 
   describe("Field Building", () => {


### PR DESCRIPTION
## Summary
- Update `SchemaBuilder` field name regex from `/^[A-Za-z0-9]+$/` to `/^[A-Za-z][A-Za-z0-9_]*$/`, matching backend (`services/agents/shelly/shelly-core/src/workflow/schema/schema-types.ts`) and dashboard (`FieldsEditor/validation.ts`).
- Update error message + JSDoc to reflect the new rule.
- Add regression tests: underscores allowed, leading-digit rejected, special chars rejected.

## Why
The alphanumeric-only restriction was lifted across the platform, but a leftover check in `SchemaBuilder` still rejected names like `company_name`. Users hit this through MCP `create_workflow`, which delegates to `SchemaBuilder.field()`.

Linear: https://linear.app/kadoa/issue/KAD-6594

## Test plan
- [x] `bun test test/unit/schema-builder.test.ts` — 32 pass
- [ ] Verify MCP `create_workflow` accepts `company_name` after a SDK release + MCP dependency bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)