### PR TITLE
feat(node-sdk): support templateId on workflow.create (KAD-6630)

### DIFF
--- a/sdks/node/src/client/wiring.ts
+++ b/sdks/node/src/client/wiring.ts
@@ -100,9 +100,12 @@ export function createClientDomains(params: { client: KadoaClient }): {
   const settingsService = new NotificationSettingsService(
     client.apis.notifications,
   );
-  const workflowsCoreService = new WorkflowsCoreService(client.apis.workflows);
   const schemasService = new SchemasService(client);
   const templatesService = new TemplatesService(client);
+  const workflowsCoreService = new WorkflowsCoreService(
+    client.apis.workflows,
+    templatesService,
+  );
   const variablesService = new VariablesService(client);
   const channelSetupService = new NotificationSetupService(
     channelsService,

--- a/sdks/node/src/domains/workflows/workflows-core.service.ts
+++ b/sdks/node/src/domains/workflows/workflows-core.service.ts
@@ -1,5 +1,6 @@
 import { KadoaSdkException } from "../../runtime/exceptions";
 import { ERROR_MESSAGES } from "../../runtime/exceptions/base.exception";
+import type { TemplatesService } from "../templates/templates.service";
 import { logger } from "../../runtime/logger";
 import {
   type PollingOptions,
@@ -25,6 +26,7 @@ import {
   type UpdateWorkflowResponse,
   type WorkflowAuditLogOptions,
   type WorkflowAuditLogResponse,
+  type WorkflowFromTemplate,
   type WorkflowResponse,
   type WorkflowStateEnum,
   type WorkflowsApiInterface,
@@ -45,9 +47,11 @@ export interface CreateWorkflowInput {
   urls: string[];
   /**
    * Natural-language instructions for the workflow (10–5000 chars).
-   * Required by the backend on every create — navigation is inferred from the prompt.
+   * Required unless creating from a published template version
+   * (i.e. when both `templateId` and `templateVersion` are supplied) —
+   * in that case the prompt is inherited from the template version.
    */
-  userPrompt: string;
+  userPrompt?: string;
   name?: string;
   description?: string;
   schemaId?: string;
@@ -61,6 +65,22 @@ export interface CreateWorkflowInput {
   schedules?: string[];
   additionalData?: Record<string, unknown>;
   limit?: number;
+  /**
+   * Instantiate a workflow from a published template. When set, only `urls`
+   * is required — `userPrompt`, `entity`, `fields`, `schemaId`,
+   * `monitoring`, and `navigationMode` must NOT be supplied; they are
+   * inherited from the resolved template version.
+   *
+   * If `templateVersion` is omitted, the SDK resolves the template's
+   * latest published version automatically.
+   */
+  templateId?: string;
+  /**
+   * Optional: Specific published version (integer) of the template to
+   * instantiate. Defaults to the template's latest published version when
+   * `templateId` is set and this field is omitted.
+   */
+  templateVersion?: number;
   /**
    * @deprecated The backend no longer accepts a `navigationMode` field —
    * navigation is inferred from `userPrompt`. Kept on the SDK input shape
@@ -93,12 +113,34 @@ export const TERMINAL_RUN_STATES: Set<string> = new Set([
 const debug = logger.workflow;
 
 export class WorkflowsCoreService {
-  constructor(private readonly workflowsApi: WorkflowsApiInterface) {}
+  constructor(
+    private readonly workflowsApi: WorkflowsApiInterface,
+    private readonly templatesService?: TemplatesService,
+  ) {}
 
   async create(input: CreateWorkflowInput): Promise<{ id: WorkflowId }> {
     validateAdditionalData(input.additionalData);
 
-    if (!input.userPrompt) {
+    const isFromTemplate = input.templateId != null;
+
+    if (isFromTemplate) {
+      const conflicting: string[] = [];
+      if (input.userPrompt != null) conflicting.push("userPrompt");
+      if (input.entity != null) conflicting.push("entity");
+      if (input.fields != null) conflicting.push("fields");
+      if (input.schemaId != null) conflicting.push("schemaId");
+      if (input.monitoring != null) conflicting.push("monitoring");
+      if (input.navigationMode != null) conflicting.push("navigationMode");
+      if (conflicting.length > 0) {
+        throw new KadoaSdkException(
+          `Fields are defined by the template and cannot be supplied when creating from a template: ${conflicting.join(", ")}`,
+          {
+            code: "VALIDATION_ERROR",
+            details: { conflicting },
+          },
+        );
+      }
+    } else if (!input.userPrompt) {
       throw new KadoaSdkException(
         "userPrompt is required to create a workflow",
         {
@@ -110,32 +152,58 @@ export class WorkflowsCoreService {
 
     const domainName = new URL(input.urls[0]).hostname;
 
-    // The OpenAPI spec dropped `navigationMode` when it consolidated the
-    // create-workflow body into `PublicWorkflowCreateRequest`, but the
-    // public-api handler still uses `detectWorkflowType` to route based
-    // on it (with a fallback that misroutes prompt-based workflows). Send
-    // it explicitly so the backend dispatches to the agentic branch.
-    const request = {
-      urls: input.urls,
-      name: input.name ?? domainName,
-      description: input.description,
-      userPrompt: input.userPrompt,
-      navigationMode: "agentic-navigation",
-      schemaId: input.schemaId,
-      ...(input.entity != null && { entity: input.entity }),
-      fields: input.fields,
-      bypassPreview: input.bypassPreview ?? true,
-      tags: input.tags,
-      interval: input.interval,
-      monitoring: input.monitoring,
-      location: input.location,
-      schedules: input.schedules,
-      additionalData: input.additionalData,
-      limit: input.limit,
-    } as PromptWorkflow;
+    let request: PromptWorkflow | WorkflowFromTemplate;
+    if (isFromTemplate) {
+      const templateId = input.templateId as string;
+      const templateVersion =
+        input.templateVersion ?? (await this.resolveLatestVersion(templateId));
+
+      request = {
+        urls: input.urls,
+        templateId,
+        templateVersion,
+        ...(input.name != null && { name: input.name }),
+        ...(input.description != null && { description: input.description }),
+        ...(input.tags != null && { tags: input.tags }),
+        ...(input.interval != null && { interval: input.interval }),
+        ...(input.schedules != null && { schedules: input.schedules }),
+        ...(input.location != null && { location: input.location }),
+        ...(input.bypassPreview != null && {
+          bypassPreview: input.bypassPreview,
+        }),
+        ...(input.additionalData != null && {
+          additionalData: input.additionalData,
+        }),
+        ...(input.limit != null && { limit: input.limit }),
+      } as WorkflowFromTemplate;
+    } else {
+      // The OpenAPI spec dropped `navigationMode` when it consolidated the
+      // create-workflow body into `PublicWorkflowCreateRequest`, but the
+      // public-api handler still uses `detectWorkflowType` to route based
+      // on it (with a fallback that misroutes prompt-based workflows). Send
+      // it explicitly so the backend dispatches to the agentic branch.
+      request = {
+        urls: input.urls,
+        name: input.name ?? domainName,
+        description: input.description,
+        userPrompt: input.userPrompt,
+        navigationMode: "agentic-navigation",
+        schemaId: input.schemaId,
+        ...(input.entity != null && { entity: input.entity }),
+        fields: input.fields,
+        bypassPreview: input.bypassPreview ?? true,
+        tags: input.tags,
+        interval: input.interval,
+        monitoring: input.monitoring,
+        location: input.location,
+        schedules: input.schedules,
+        additionalData: input.additionalData,
+        limit: input.limit,
+      } as PromptWorkflow;
+    }
 
     const response = await this.workflowsApi.v4WorkflowsPost({
-      publicWorkflowCreateRequest: request,
+      publicWorkflowCreateRequest: request as PromptWorkflow,
     });
     const workflowId = response.data?.workflowId;
 
@@ -148,6 +216,30 @@ export class WorkflowsCoreService {
       });
     }
     return { id: workflowId };
+  }
+
+  private async resolveLatestVersion(templateId: string): Promise<number> {
+    if (!this.templatesService) {
+      throw new KadoaSdkException(
+        "TemplatesService is required to resolve a template's latest version. Pass `templateVersion` explicitly or construct WorkflowsCoreService with a TemplatesService.",
+        {
+          code: "INTERNAL_ERROR",
+          details: { templateId },
+        },
+      );
+    }
+    const template = await this.templatesService.get(templateId);
+    const latest = (template as { latestVersion?: number | null }).latestVersion;
+    if (latest == null) {
+      throw new KadoaSdkException(
+        `Template ${templateId} has no published versions; supply templateVersion explicitly or publish a version first.`,
+        {
+          code: "VALIDATION_ERROR",
+          details: { templateId },
+        },
+      );
+    }
+    return latest;
   }
 
   async get(id: WorkflowId): Promise<GetWorkflowResponse> {

--- a/sdks/node/src/domains/workflows/workflows.acl.ts
+++ b/sdks/node/src/domains/workflows/workflows.acl.ts
@@ -25,6 +25,7 @@ import type {
   V4WorkflowsWorkflowIdMetadataPutRequest,
   V4WorkflowsWorkflowIdRunPut200Response,
   V4WorkflowsWorkflowIdRunPutRequest,
+  WorkflowFromTemplate,
   WorkflowsApiInterface,
   WorkflowsApiV4WorkflowsGetRequest,
   WorkflowWithEntityAndFields,
@@ -201,7 +202,7 @@ export type CreateWorkflowRequest = WorkflowWithExistingSchema;
 
 export type CreateWorkflowWithCustomSchemaRequest = WorkflowWithEntityAndFields;
 
-export type { PromptWorkflow };
+export type { PromptWorkflow, WorkflowFromTemplate };
 
 /**
  * @deprecated Renamed to `PromptWorkflow` upstream. Kept for backwards

--- a/sdks/node/test/unit/workflows-create-from-template.test.ts
+++ b/sdks/node/test/unit/workflows-create-from-template.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../../src/runtime/utils/version-check", () => ({
+  checkForUpdates: () => Promise.resolve(),
+}));
+
+import { KadoaClient } from "../../src/client/kadoa-client";
+import { KadoaSdkException } from "../../src/runtime/exceptions";
+
+const TEMPLATE_ID = "11111111-1111-4111-8111-111111111111";
+
+function createTestClient(
+  mockPost: ReturnType<typeof mock>,
+  mockTemplateGet?: ReturnType<typeof mock>,
+): KadoaClient {
+  const client = new KadoaClient({ apiKey: "tk-test" });
+  (client.apis.workflows as any).v4WorkflowsPost = mockPost;
+  if (mockTemplateGet) {
+    (client.template as any).get = mockTemplateGet;
+  }
+  return client;
+}
+
+describe("WorkflowsCoreService.create — templateId support", () => {
+  test("uses explicit templateVersion when supplied", async () => {
+    const mockPost = mock(() =>
+      Promise.resolve({ data: { workflowId: "wf-1" } }),
+    );
+    const mockTemplateGet = mock();
+    const client = createTestClient(mockPost, mockTemplateGet);
+
+    const result = await client.workflow.create({
+      urls: ["https://example.com"],
+      templateId: TEMPLATE_ID,
+      templateVersion: 3,
+      tags: ["from-template"],
+    });
+
+    expect(result.id).toBe("wf-1");
+    expect(mockTemplateGet).not.toHaveBeenCalled();
+    const body = mockPost.mock.calls[0]?.[0]?.publicWorkflowCreateRequest;
+    expect(body.urls).toEqual(["https://example.com"]);
+    expect(body.templateId).toBe(TEMPLATE_ID);
+    expect(body.templateVersion).toBe(3);
+    expect(body.tags).toEqual(["from-template"]);
+    expect(body.userPrompt).toBeUndefined();
+    expect(body.navigationMode).toBeUndefined();
+    expect(body.entity).toBeUndefined();
+    expect(body.fields).toBeUndefined();
+    expect(body.schemaId).toBeUndefined();
+    expect(body.monitoring).toBeUndefined();
+  });
+
+  test("resolves latest version when only templateId is supplied", async () => {
+    const mockPost = mock(() =>
+      Promise.resolve({ data: { workflowId: "wf-2" } }),
+    );
+    const mockTemplateGet = mock(() =>
+      Promise.resolve({ id: TEMPLATE_ID, latestVersion: 7, versions: [] }),
+    );
+    const client = createTestClient(mockPost, mockTemplateGet);
+
+    const result = await client.workflow.create({
+      urls: ["https://example.com"],
+      templateId: TEMPLATE_ID,
+    });
+
+    expect(result.id).toBe("wf-2");
+    expect(mockTemplateGet).toHaveBeenCalledWith(TEMPLATE_ID);
+    const body = mockPost.mock.calls[0]?.[0]?.publicWorkflowCreateRequest;
+    expect(body.templateId).toBe(TEMPLATE_ID);
+    expect(body.templateVersion).toBe(7);
+  });
+
+  test("throws when template has no published versions", async () => {
+    const mockPost = mock();
+    const mockTemplateGet = mock(() =>
+      Promise.resolve({ id: TEMPLATE_ID, latestVersion: null, versions: [] }),
+    );
+    const client = createTestClient(mockPost, mockTemplateGet);
+
+    await expect(
+      client.workflow.create({
+        urls: ["https://example.com"],
+        templateId: TEMPLATE_ID,
+      }),
+    ).rejects.toBeInstanceOf(KadoaSdkException);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  test("rejects userPrompt when creating from a template", async () => {
+    const mockPost = mock();
+    const client = createTestClient(mockPost);
+
+    await expect(
+      client.workflow.create({
+        urls: ["https://example.com"],
+        templateId: TEMPLATE_ID,
+        templateVersion: 1,
+        userPrompt: "should not be allowed",
+      }),
+    ).rejects.toBeInstanceOf(KadoaSdkException);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  test("still requires userPrompt when no templateId is supplied", async () => {
+    const mockPost = mock();
+    const client = createTestClient(mockPost);
+
+    await expect(
+      client.workflow.create({
+        urls: ["https://example.com"],
+      } as any),
+    ).rejects.toBeInstanceOf(KadoaSdkException);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Expose `templateId` (and optional `templateVersion`) on `workflow.create`. When `templateId` is set the SDK sends the new `WorkflowFromTemplate` variant added in kadoa-org/kadoa-backend#8271 — only `urls` is required and prompt, schema, and notifications are inherited from the resolved template version.
- If `templateVersion` is omitted, the SDK resolves the template's latest published version automatically (one extra `GET /v4/templates/{id}` call) so callers can opt into "always use latest" without round-tripping themselves.
- Conflicting fields (`userPrompt`, `entity`, `fields`, `schemaId`, `monitoring`, `navigationMode`) are rejected client-side before the POST, with a clear error.
- Re-syncs `specs/openapi.json` against the live spec to pick up `WorkflowFromTemplate` + `templateVersion`.

Linear: [KAD-6630](https://linear.app/kadoa/issue/KAD-6630)

## Test plan
- [x] Unit: `test/unit/workflows-create-from-template.test.ts` — explicit version, latest auto-resolve, no-published-versions error, conflicting-fields rejection, still-requires-userPrompt fallback.
- [x] Full unit suite: 83 tests pass.
- [x] `tsc --noEmit` clean.
- [x] Manual e2e against `api.kadoa.com`: created template + version 1, created workflow with explicit `templateVersion`, created workflow with `templateId` only (SDK resolved latest = 1), both workflows reached `ACTIVE` with the expected `templateId`/`templateVersion` provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)