### PR TITLE
feat(node-sdk): add extraction.exportData for signed-URL data export (KAD-7026)

### DIFF
--- a/sdks/node/src/domains/extraction/index.ts
+++ b/sdks/node/src/domains/extraction/index.ts
@@ -23,7 +23,12 @@ export type {
 export { FetchDataOptions, SchemaFieldDataType } from "./extraction.acl";
 
 // Data fetcher types and service (owned by data-fetcher.service.ts)
-export type { FetchDataResult } from "./services/data-fetcher.service";
+export type {
+  ExportDataFormat,
+  ExportDataOptions,
+  ExportDataResult,
+  FetchDataResult,
+} from "./services/data-fetcher.service";
 export { DataFetcherService } from "./services/data-fetcher.service";
 // Entity resolver service
 export { EntityResolverService } from "./services/entity-resolver.service";

--- a/sdks/node/src/domains/extraction/services/data-fetcher.service.ts
+++ b/sdks/node/src/domains/extraction/services/data-fetcher.service.ts
@@ -1,5 +1,6 @@
 import { PagedIterator, type PagedResponse } from "../../../runtime/pagination";
 import type {
+  DataSortOrder,
   FetchDataOptions,
   WorkflowsApiInterface,
 } from "../extraction.acl";
@@ -8,6 +9,46 @@ export interface FetchDataResult extends PagedResponse<object> {
   workflowId: string;
   runId?: string | null;
   executedAt?: string | null;
+}
+
+export type ExportDataFormat = "csv" | "json";
+
+/**
+ * Options for requesting a materialized data export.
+ */
+export interface ExportDataOptions {
+  workflowId: string;
+  /**
+   * Output format for the materialized export. Defaults to `"csv"`.
+   */
+  format?: ExportDataFormat;
+  runId?: string;
+  /**
+   * JSON-encoded filter array; same shape accepted by the `/data` endpoint.
+   */
+  filters?: string;
+  sortBy?: string;
+  order?: DataSortOrder;
+  /**
+   * Comma-separated list (or JSON array) of row ids to include.
+   */
+  rowIds?: string;
+}
+
+/**
+ * Result of {@link DataFetcherService.exportData}. The backend materializes
+ * the full result set and returns a self-authenticating signed URL that can
+ * be opened by external clients (browsers, Claude Desktop, sandboxes, etc.)
+ * without an Authorization header. Valid until `expiresAt`.
+ */
+export interface ExportDataResult {
+  workflowId: string;
+  runId: string;
+  executedAt?: string;
+  format: ExportDataFormat;
+  rowCount: number;
+  url: string;
+  expiresAt: string;
 }
 
 /**
@@ -44,6 +85,29 @@ export class DataFetcherService {
     );
 
     return iterator.fetchAll({ limit: options.limit ?? this.defaultLimit });
+  }
+
+  /**
+   * Materialize the workflow's full data set and return a signed,
+   * self-authenticating download URL. The URL works without an
+   * Authorization header (suitable for browsers, Claude Desktop, code
+   * execution sandboxes, etc.) and is valid until `expiresAt`. Callers
+   * download with a plain `fetch(result.url)`.
+   */
+  async exportData(options: ExportDataOptions): Promise<ExportDataResult> {
+    const response = await this.workflowsApi.v4WorkflowsWorkflowIdDataExportGet(
+      {
+        workflowId: options.workflowId,
+        format: options.format,
+        runId: options.runId,
+        filters: options.filters,
+        sortBy: options.sortBy,
+        order: options.order,
+        rowIds: options.rowIds,
+      },
+    );
+
+    return response.data as ExportDataResult;
   }
 
   /**

--- a/sdks/node/src/domains/extraction/services/extraction.service.ts
+++ b/sdks/node/src/domains/extraction/services/extraction.service.ts
@@ -27,6 +27,8 @@ import type {
 } from "../extraction.acl";
 import type {
   DataFetcherService,
+  ExportDataOptions,
+  ExportDataResult,
   FetchDataResult,
 } from "./data-fetcher.service";
 import type { EntityConfig } from "./entity-resolver.service";
@@ -182,6 +184,16 @@ export class ExtractionService {
    */
   async fetchAllData(options: FetchDataOptions): Promise<object[]> {
     return await this.dataFetcherService.fetchAllData(options);
+  }
+
+  /**
+   * Materialize a full data export and receive a signed, self-authenticating
+   * download URL. Supports `format: "csv" | "json"` (default `"csv"`). The
+   * URL is valid until `expiresAt` and can be opened by external clients
+   * without auth headers — download with `fetch(result.url)`.
+   */
+  async exportData(options: ExportDataOptions): Promise<ExportDataResult> {
+    return await this.dataFetcherService.exportData(options);
   }
 
   /**

--- a/sdks/node/test/unit/data-fetcher-export.test.ts
+++ b/sdks/node/test/unit/data-fetcher-export.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { WorkflowsApiInterface } from "../../src/domains/extraction";
+import { DataFetcherService } from "../../src/domains/extraction/services/data-fetcher.service";
+
+describe("DataFetcherService.exportData", () => {
+  test("calls /data/export with all forwarded query params", async () => {
+    const v4WorkflowsWorkflowIdDataExportGet = mock(async () => ({
+      data: {
+        workflowId: "wf-1",
+        runId: "run-9",
+        executedAt: "2026-05-11T12:00:00Z",
+        format: "json",
+        rowCount: 42,
+        url: "https://exports.kadoa.com/signed/abc?sig=xyz",
+        expiresAt: "2026-05-12T12:00:00Z",
+      },
+    }));
+
+    const api = {
+      v4WorkflowsWorkflowIdDataExportGet,
+    } as unknown as WorkflowsApiInterface;
+
+    const service = new DataFetcherService(api);
+    const result = await service.exportData({
+      workflowId: "wf-1",
+      format: "json",
+      runId: "run-9",
+      filters: "[]",
+      sortBy: "createdAt",
+      order: "asc",
+      rowIds: "1,2,3",
+    });
+
+    expect(v4WorkflowsWorkflowIdDataExportGet).toHaveBeenCalledWith({
+      workflowId: "wf-1",
+      format: "json",
+      runId: "run-9",
+      filters: "[]",
+      sortBy: "createdAt",
+      order: "asc",
+      rowIds: "1,2,3",
+    });
+    expect(result.url).toContain("https://exports.kadoa.com/signed/abc");
+    expect(result.format).toBe("json");
+    expect(result.rowCount).toBe(42);
+  });
+
+  test("defaults are left to the backend when only workflowId is given", async () => {
+    const v4WorkflowsWorkflowIdDataExportGet = mock(async () => ({
+      data: {
+        workflowId: "wf-1",
+        runId: "run-9",
+        format: "csv",
+        rowCount: 0,
+        url: "https://exports.kadoa.com/signed/abc",
+        expiresAt: "2026-05-12T12:00:00Z",
+      },
+    }));
+
+    const api = {
+      v4WorkflowsWorkflowIdDataExportGet,
+    } as unknown as WorkflowsApiInterface;
+
+    const service = new DataFetcherService(api);
+    await service.exportData({ workflowId: "wf-1" });
+
+    expect(v4WorkflowsWorkflowIdDataExportGet).toHaveBeenCalledWith({
+      workflowId: "wf-1",
+      format: undefined,
+      runId: undefined,
+      filters: undefined,
+      sortBy: undefined,
+      order: undefined,
+      rowIds: undefined,
+    });
+  });
+});

--- a/sdks/node/test/unit/extraction-service.test.ts
+++ b/sdks/node/test/unit/extraction-service.test.ts
@@ -205,4 +205,41 @@ describe("ExtractionService", () => {
       userPrompt: "extract only in-stock items",
     });
   });
+
+  test("exportData delegates to data fetcher and returns the signed URL payload", async () => {
+    const exportData = mock(async () => ({
+      workflowId: "wf-export",
+      runId: "run-1",
+      executedAt: "2026-05-11T12:00:00Z",
+      format: "csv" as const,
+      rowCount: 1234,
+      url: "https://exports.kadoa.com/signed/abc?sig=xyz",
+      expiresAt: "2026-05-12T00:00:00Z",
+    }));
+
+    const service = new ExtractionService(
+      {} as ConstructorParameters<typeof ExtractionService>[0],
+      { exportData } as unknown as ConstructorParameters<
+        typeof ExtractionService
+      >[1],
+      {} as ConstructorParameters<typeof ExtractionService>[2],
+      {} as ConstructorParameters<typeof ExtractionService>[3],
+      {} as ConstructorParameters<typeof ExtractionService>[4],
+    );
+
+    const result = await service.exportData({
+      workflowId: "wf-export",
+      format: "csv",
+    });
+
+    expect(exportData).toHaveBeenCalledWith({
+      workflowId: "wf-export",
+      format: "csv",
+    });
+    expect(result).toMatchObject({
+      url: "https://exports.kadoa.com/signed/abc?sig=xyz",
+      rowCount: 1234,
+      format: "csv",
+    });
+  });
 });

--- a/specs/openapi-metadata.json
+++ b/specs/openapi-metadata.json
@@ -1,6 +1,6 @@
 {
-  "fetchedAt": "2026-05-06T11:49:52.266Z",
+  "fetchedAt": "2026-05-11T13:17:23.497Z",
   "apiVersion": "3.0.0",
-  "checksum": "1cdb14e20ab64161c6266712f6547dcb7e202b5ee0492c4aa55409084896b8d0",
+  "checksum": "a3497781ddfd33532d19f4be0e362f4d0589a799c27800bb09984957da16755f",
   "endpoint": "https://api.kadoa.com/openapi"
 }

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -1825,6 +1825,10 @@
                       "type": "string",
                       "description": "Update frequency"
                     },
+                    "isRealTime": {
+                      "type": "boolean",
+                      "description": "Whether this workflow should be displayed as realtime"
+                    },
                     "schedules": {
                       "type": "array",
                       "items": {
@@ -2757,6 +2761,150 @@
         ]
       }
     },
+    "/v4/workflows/{workflowId}/data/export": {
+      "get": {
+        "summary": "Materialize a full data export and return a signed download URL",
+        "description": "Materializes the full result set as CSV or JSON to object storage and returns a self-authenticating\nURL that can be opened by external clients (Claude Desktop, Claude for Excel, code execution sandboxes,\nbrowsers) without an Authorization header. The URL is HMAC-signed and bound to the exportId, workflowId,\nformat and expiry.\n",
+        "tags": [
+          "Workflows"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workflowId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "csv",
+                "json"
+              ],
+              "default": "csv"
+            }
+          },
+          {
+            "name": "runId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filters",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "asc"
+            }
+          },
+          {
+            "name": "rowIds",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Export materialized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "workflowId",
+                    "runId",
+                    "format",
+                    "rowCount",
+                    "url",
+                    "expiresAt"
+                  ],
+                  "properties": {
+                    "workflowId": {
+                      "type": "string"
+                    },
+                    "runId": {
+                      "type": "string"
+                    },
+                    "executedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "format": {
+                      "type": "string",
+                      "enum": [
+                        "csv",
+                        "json"
+                      ]
+                    },
+                    "rowCount": {
+                      "type": "integer"
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "Signed, self-authenticating download URL. Valid until expiresAt."
+                    },
+                    "expiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query params"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Workflow or run not found"
+          }
+        }
+      }
+    },
     "/v4/workflows/{workflowId}/data/exports/{exportId}": {
       "get": {
         "summary": "Download a materialized CSV export",
@@ -2958,7 +3106,7 @@
             "description": "Unauthorized access, either due to missing or invalid x-api-key"
           },
           "404": {
-            "description": "Workflow runs for the specified ID could not be found"
+            "description": "Workflow with the specified ID could not be found"
           }
         }
       }
@@ -3050,6 +3198,34 @@
           },
           "403": {
             "description": "403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "description": "Indicates an error occurred"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    },
+                    "details": {
+                      "nullable": true,
+                      "description": "Additional error details (e.g., validation errors)"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
             "content": {
               "application/json": {
                 "schema": {
@@ -3421,6 +3597,14 @@
                             "type": "string",
                             "format": "date-time",
                             "description": "Timestamp when the workflow was created"
+                          },
+                          "updateInterval": {
+                            "type": "string",
+                            "description": "Update frequency"
+                          },
+                          "isRealTime": {
+                            "type": "boolean",
+                            "description": "Whether this workflow should be displayed as realtime"
                           },
                           "tags": {
                             "type": "array",
@@ -21206,58 +21390,6 @@
         "title": "Location",
         "description": "Geographic location for scraping. Use 'auto' for automatic detection or 'manual' to specify a country"
       },
-      "MonitoredField": {
-        "type": "object",
-        "properties": {
-          "fieldName": {
-            "type": "string",
-            "description": "Name of the field to monitor"
-          },
-          "operator": {
-            "type": "string",
-            "enum": [
-              "changed",
-              "added",
-              "removed"
-            ],
-            "description": "Change operator"
-          }
-        },
-        "required": [
-          "fieldName",
-          "operator"
-        ],
-        "title": "MonitoredField",
-        "description": "Field monitoring configuration"
-      },
-      "MonitoringConfig": {
-        "description": "Monitoring configuration",
-        "type": "object",
-        "properties": {
-          "fields": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MonitoredField"
-            },
-            "minItems": 1,
-            "description": "Fields to monitor (at least one required)"
-          },
-          "channels": {
-            "type": "array",
-            "items": {
-              "nullable": true
-            },
-            "description": "Notification channels"
-          },
-          "conditions": {
-            "description": "Condition group with logical operator and conditions"
-          }
-        },
-        "required": [
-          "fields"
-        ],
-        "title": "MonitoringConfig"
-      },
       "BrowserInteraction": {
         "type": "object",
         "properties": {
@@ -21425,6 +21557,167 @@
         "title": "Interaction",
         "description": "Browser interaction definition. Accepts both simple format (with selector, text, url) and complex format from browser extensions"
       },
+      "WorkflowFromTemplate": {
+        "type": "object",
+        "properties": {
+          "urls": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            },
+            "minItems": 1,
+            "description": "List of URLs to scrape. Can be a single URL or multiple URLs to scrape across different pages or domains."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Human-readable name for this workflow (e.g., 'Product Catalog Scraper')"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Detailed description of what this workflow does and why it was created (maximum 500 characters)"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 2
+            },
+            "description": "Tags for organizing and categorizing workflows (minimum 2 characters per tag)"
+          },
+          "interval": {
+            "type": "string",
+            "enum": [
+              "ONLY_ONCE",
+              "EVERY_10_MINUTES",
+              "HALF_HOURLY",
+              "HOURLY",
+              "THREE_HOURLY",
+              "SIX_HOURLY",
+              "TWELVE_HOURLY",
+              "EIGHTEEN_HOURLY",
+              "DAILY",
+              "TWO_DAY",
+              "THREE_DAY",
+              "WEEKLY",
+              "BIWEEKLY",
+              "TRIWEEKLY",
+              "FOUR_WEEKS",
+              "MONTHLY",
+              "REAL_TIME",
+              "CUSTOM"
+            ],
+            "description": "How frequently this workflow should run (ONLY_ONCE, HOURLY, DAILY, WEEKLY, etc.)"
+          },
+          "schedules": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Cron expressions for custom schedules. Overrides the interval setting for fine-grained control"
+          },
+          "location": {
+            "$ref": "#/components/schemas/Location"
+          },
+          "bypassPreview": {
+            "default": false,
+            "type": "boolean",
+            "description": "Skip preview and validation, deploy scraper immediately. Use with caution - set to true only when you're confident the configuration is correct"
+          },
+          "additionalData": {
+            "nullable": true,
+            "description": "Additional data for the workflow (e.g. IDs from your system to link data)"
+          },
+          "interactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Interaction"
+            },
+            "description": "Browser interactions to perform before scraping (e.g., clicking buttons, filling forms, scrolling). See Interaction schema for available action types"
+          },
+          "dataValidationEnabled": {
+            "type": "boolean",
+            "description": "Enable data quality validation. When true, scraped data is validated against the schema and anomalies are detected"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Maximum number of items to scrape. Useful for limiting scope during development or cost control"
+          },
+          "templateId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the template to instantiate."
+          },
+          "templateVersion": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Version (integer) of the template to instantiate. Both templateId and templateVersion must be provided together."
+          }
+        },
+        "required": [
+          "urls",
+          "templateId",
+          "templateVersion"
+        ],
+        "additionalProperties": true,
+        "title": "WorkflowFromTemplate",
+        "description": "Create a workflow by instantiating a published template version. Only `urls` is required; prompt, schema, and notifications are inherited from the template version.\n\nExample: `{\"urls\": [\"https://example.com\"], \"templateId\": \"...\", \"templateVersion\": 1}`"
+      },
+      "MonitoredField": {
+        "type": "object",
+        "properties": {
+          "fieldName": {
+            "type": "string",
+            "description": "Name of the field to monitor"
+          },
+          "operator": {
+            "type": "string",
+            "enum": [
+              "changed",
+              "added",
+              "removed"
+            ],
+            "description": "Change operator"
+          }
+        },
+        "required": [
+          "fieldName",
+          "operator"
+        ],
+        "title": "MonitoredField",
+        "description": "Field monitoring configuration"
+      },
+      "MonitoringConfig": {
+        "description": "Monitoring configuration",
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MonitoredField"
+            },
+            "minItems": 1,
+            "description": "Fields to monitor (at least one required)"
+          },
+          "channels": {
+            "type": "array",
+            "items": {
+              "nullable": true
+            },
+            "description": "Notification channels"
+          },
+          "conditions": {
+            "description": "Condition group with logical operator and conditions"
+          }
+        },
+        "required": [
+          "fields"
+        ],
+        "title": "MonitoringConfig"
+      },
       "PromptWorkflow": {
         "type": "object",
         "properties": {
@@ -21521,6 +21814,10 @@
             "type": "string",
             "format": "uuid",
             "description": "Optional: ID of the template this workflow was created from. Records provenance only — the template's config is cloned at creation, not synced."
+          },
+          "templateVersion": {
+            "readOnly": true,
+            "description": "Reserved: only valid in the WorkflowFromTemplate variant. Pairs with templateId to instantiate a specific template version."
           },
           "userPrompt": {
             "type": "string",
@@ -21649,6 +21946,10 @@
               "type": "string"
             },
             "description": "Cron expressions for custom schedules"
+          },
+          "templateVersion": {
+            "readOnly": true,
+            "description": "Reserved: only valid in the WorkflowFromTemplate variant."
           }
         },
         "required": [
@@ -21800,6 +22101,10 @@
             "type": "string",
             "format": "uuid",
             "description": "Optional: ID of the template this workflow was created from. Records provenance only — the template's config is cloned at creation, not synced."
+          },
+          "templateVersion": {
+            "readOnly": true,
+            "description": "Reserved: only valid in the WorkflowFromTemplate variant. Pairs with templateId to instantiate a specific template version."
           },
           "schemaId": {
             "type": "string",
@@ -21956,6 +22261,10 @@
             "format": "uuid",
             "description": "Optional: ID of the template this workflow was created from. Records provenance only — the template's config is cloned at creation, not synced."
           },
+          "templateVersion": {
+            "readOnly": true,
+            "description": "Reserved: only valid in the WorkflowFromTemplate variant. Pairs with templateId to instantiate a specific template version."
+          },
           "entity": {
             "type": "string",
             "minLength": 1,
@@ -22085,6 +22394,10 @@
             "type": "string",
             "format": "uuid",
             "description": "Optional: ID of the template this workflow was created from. Records provenance only — the template's config is cloned at creation, not synced."
+          },
+          "templateVersion": {
+            "readOnly": true,
+            "description": "Reserved: only valid in the WorkflowFromTemplate variant. Pairs with templateId to instantiate a specific template version."
           },
           "userPrompt": {
             "type": "string",
@@ -22241,6 +22554,22 @@
           "isBuildStaleVsCurrent": {
             "type": "boolean",
             "description": "True when runBuildId is set and differs from currentBuildId — the script that produced this run's data is no longer the latest"
+          },
+          "workspaceClean": {
+            "type": "boolean",
+            "description": "True when the live Shelly workspace matches the latest completed build input; null when unknown",
+            "nullable": true
+          },
+          "freshnessReason": {
+            "type": "string",
+            "enum": [
+              "config_drift",
+              "build_drift",
+              "workspace_dirty",
+              "no_build_yet"
+            ],
+            "description": "Priority freshness reason for the snapshot block; null when config, build, and workspace are fresh",
+            "nullable": true
           }
         },
         "required": [
@@ -22251,7 +22580,9 @@
           "driftKeys",
           "runBuildId",
           "currentBuildId",
-          "isBuildStaleVsCurrent"
+          "isBuildStaleVsCurrent",
+          "workspaceClean",
+          "freshnessReason"
         ],
         "title": "JobStatusSnapshotBlock",
         "description": "ADR-009 snapshot drift block; null for runs predating the snapshot migration"
@@ -22722,6 +23053,10 @@
             "type": "string",
             "format": "uuid",
             "description": "Optional: ID of the template this workflow was created from. Records provenance only — the template's config is cloned at creation, not synced."
+          },
+          "templateVersion": {
+            "readOnly": true,
+            "description": "Reserved: only valid in the WorkflowFromTemplate variant. Pairs with templateId to instantiate a specific template version."
           },
           "userPrompt": {
             "type": "string",


### PR DESCRIPTION
## Summary
- Adds `client.extraction.exportData(...)` to `@kadoa/node-sdk`, exposing the new `GET /v4/workflows/{workflowId}/data/export` endpoint shipped by KAD-6596.
- Materializes a full CSV or JSON export to object storage and returns a signed, self-authenticating download URL — external clients (browsers, Claude Desktop, sandboxes) open it with a plain `fetch(result.url)`, no auth header required.
- Refreshes the committed OpenAPI spec to pick up the new endpoint.

## Public surface

```ts
client.extraction.exportData({
  workflowId: string;
  format?: "csv" | "json"; // default: "csv"
  runId?: string;
  filters?: string;        // JSON-encoded array, same shape as /data
  sortBy?: string;
  order?: "asc" | "desc";
  rowIds?: string;
}): Promise<{
  workflowId: string;
  runId: string;
  executedAt?: string;
  format: "csv" | "json";
  rowCount: number;
  url: string;             // self-authenticating signed URL
  expiresAt: string;
}>
```

## Test plan
- [x] Unit tests for `DataFetcherService.exportData` (param forwarding)
- [x] Unit tests for `ExtractionService.exportData` (delegation)
- [x] Typecheck + biome clean
- [x] End-to-end verification against prod (`api.kadoa.com`):
  - csv + json formats
  - `sortBy` / `order` / `filters` / `rowIds`
  - error paths: 404 (unknown workflow/run), 400 (malformed UUID, bad filters JSON)
  - signed-URL tamper: missing/mutated `sig`, expired, swapped `format` → all 401

## Linear
KAD-7026

## Follow-ups
- KAD-7030 tracks the Python SDK parity audit (includes `export_data` on the Python side).