### PR TITLE
fix(node-sdk): route domain auth through axios interceptor

### DIFF
--- a/sdks/node/src/client/kadoa-client.ts
+++ b/sdks/node/src/client/kadoa-client.ts
@@ -9,9 +9,9 @@ import type {
 } from "../domains/extraction/services/extraction-builder.service";
 import { Realtime, type RealtimeConfig } from "../domains/realtime";
 import type { SchemasService } from "../domains/schemas/schemas.service";
+import type { TemplatesService } from "../domains/templates/templates.service";
 import type { UserService } from "../domains/user/user.service";
 import type { ValidationDomain } from "../domains/validation/validation.facade";
-import type { TemplatesService } from "../domains/templates/templates.service";
 import type { VariablesService } from "../domains/variables/variables.service";
 import type { WorkflowsCoreService } from "../domains/workflows/workflows-core.service";
 import { PUBLIC_API_URI } from "../runtime/config";
@@ -95,6 +95,10 @@ export class KadoaClient {
           reqConfig.headers["Authorization"] = `Bearer ${this._bearerToken}`;
         }
         delete reqConfig.headers["x-api-key"];
+      } else if (this._apiKey && !reqConfig.headers["x-api-key"]) {
+        // ApiKey mode: ensure x-api-key for direct axios calls that
+        // bypass the generated clients (which set x-api-key via Configuration).
+        reqConfig.headers["x-api-key"] = this._apiKey;
       }
       return reqConfig;
     });

--- a/sdks/node/src/domains/extraction/services/entity-resolver.service.ts
+++ b/sdks/node/src/domains/extraction/services/entity-resolver.service.ts
@@ -137,7 +137,6 @@ export class EntityResolverService {
         headers: {
           "Content-Type": "application/json",
           Accept: "application/json",
-          "x-api-key": this.client.apiKey,
         },
       });
 

--- a/sdks/node/src/domains/user/user.service.ts
+++ b/sdks/node/src/domains/user/user.service.ts
@@ -18,7 +18,6 @@ export class UserService {
     const response = await this.client.axiosInstance.get("/v5/user", {
       baseURL: this.client.baseUrl,
       headers: {
-        "x-api-key": this.client.apiKey,
         "Content-Type": "application/json",
       },
     });

--- a/sdks/node/test/unit/entity-resolver.service.test.ts
+++ b/sdks/node/test/unit/entity-resolver.service.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AxiosResponse, InternalAxiosRequestConfig } from "axios";
+import { KadoaClient } from "../../src/client/kadoa-client";
+import { EntityResolverService } from "../../src/domains/extraction/services/entity-resolver.service";
+
+mock.module("../../src/runtime/utils/version-check", () => ({
+  checkForUpdates: () => Promise.resolve(),
+}));
+
+async function captureRequest(
+  client: KadoaClient,
+  call: () => Promise<unknown>,
+): Promise<InternalAxiosRequestConfig> {
+  let captured: InternalAxiosRequestConfig | undefined;
+  client.axiosInstance.defaults.adapter = async (config) => {
+    captured = config;
+    return {
+      data: {
+        success: true,
+        entityPrediction: [{ entity: "Product", fields: [] }],
+      },
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config,
+    } as AxiosResponse;
+  };
+  await call();
+  if (!captured) throw new Error("no request captured");
+  return captured;
+}
+
+describe("EntityResolverService.fetchEntityFields auth headers", () => {
+  test("bearer-only mode emits Authorization and no x-api-key", async () => {
+    const client = new KadoaClient({ bearerToken: "jwt-test" });
+    const resolver = new EntityResolverService(client);
+    const req = await captureRequest(client, () =>
+      resolver.fetchEntityFields({ link: "https://example.com" }),
+    );
+    expect(req.headers["Authorization"]).toBe("Bearer jwt-test");
+    expect(req.headers["x-api-key"]).toBeUndefined();
+  });
+
+  test("apiKey mode emits x-api-key and no Authorization", async () => {
+    const client = new KadoaClient({ apiKey: "tk-test" });
+    const resolver = new EntityResolverService(client);
+    const req = await captureRequest(client, () =>
+      resolver.fetchEntityFields({ link: "https://example.com" }),
+    );
+    expect(req.headers["x-api-key"]).toBe("tk-test");
+    expect(req.headers["Authorization"]).toBeUndefined();
+  });
+});

--- a/sdks/node/test/unit/kadoa-client-auth.test.ts
+++ b/sdks/node/test/unit/kadoa-client-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
-import axios from "axios";
 import type { InternalAxiosRequestConfig } from "axios";
+import axios from "axios";
 import { KadoaClient } from "../../src/client/kadoa-client";
 import { KadoaSdkException } from "../../src/runtime/exceptions";
 
@@ -56,9 +56,8 @@ describe("KadoaClient auth", () => {
       initial: Partial<InternalAxiosRequestConfig>,
     ): InternalAxiosRequestConfig {
       // Access the interceptor handlers from axios internals
-      const handlers = (
-        client.axiosInstance.interceptors.request as any
-      ).handlers as Array<{
+      const handlers = (client.axiosInstance.interceptors.request as any)
+        .handlers as Array<{
         fulfilled: (
           config: InternalAxiosRequestConfig,
         ) => InternalAxiosRequestConfig;
@@ -101,6 +100,20 @@ describe("KadoaClient auth", () => {
       expect(result.headers["Authorization"]).toBeUndefined();
     });
 
+    test("injects x-api-key when only apiKey is used", () => {
+      const client = new KadoaClient({ apiKey: "tk-test" });
+      const result = runInterceptors(client, {});
+      expect(result.headers["x-api-key"]).toBe("tk-test");
+    });
+
+    test("does not override existing x-api-key header in apiKey mode", () => {
+      const client = new KadoaClient({ apiKey: "tk-test" });
+      const result = runInterceptors(client, {
+        headers: new axios.AxiosHeaders({ "x-api-key": "override-key" }),
+      });
+      expect(result.headers["x-api-key"]).toBe("override-key");
+    });
+
     test("does not override existing Authorization header", () => {
       const client = new KadoaClient({ bearerToken: "instance-jwt" });
       const result = runInterceptors(client, {
@@ -117,9 +130,8 @@ describe("KadoaClient auth", () => {
       const client = new KadoaClient({ apiKey: "tk-test" });
 
       // Initially no bearer — interceptor should not set Authorization
-      const handlers = (
-        client.axiosInstance.interceptors.request as any
-      ).handlers as Array<{
+      const handlers = (client.axiosInstance.interceptors.request as any)
+        .handlers as Array<{
         fulfilled: (
           config: InternalAxiosRequestConfig,
         ) => InternalAxiosRequestConfig;

--- a/sdks/node/test/unit/user.service.test.ts
+++ b/sdks/node/test/unit/user.service.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AxiosResponse, InternalAxiosRequestConfig } from "axios";
+import { KadoaClient } from "../../src/client/kadoa-client";
+
+mock.module("../../src/runtime/utils/version-check", () => ({
+  checkForUpdates: () => Promise.resolve(),
+}));
+
+/**
+ * Capture the final request config (after all interceptors) by stubbing
+ * the axios adapter to short-circuit the network call with a fake response.
+ */
+async function captureRequest(
+  client: KadoaClient,
+  call: () => Promise<unknown>,
+  response: unknown = {
+    userId: "u1",
+    email: "u@example.com",
+    featureFlags: [],
+  },
+): Promise<InternalAxiosRequestConfig> {
+  let captured: InternalAxiosRequestConfig | undefined;
+  client.axiosInstance.defaults.adapter = async (config) => {
+    captured = config;
+    return {
+      data: response,
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config,
+    } as AxiosResponse;
+  };
+  await call();
+  if (!captured) throw new Error("no request captured");
+  return captured;
+}
+
+describe("UserService.getCurrentUser auth headers", () => {
+  test("bearer-only mode emits Authorization and no x-api-key", async () => {
+    const client = new KadoaClient({ bearerToken: "jwt-test" });
+    const req = await captureRequest(client, () =>
+      client.user.getCurrentUser(),
+    );
+    expect(req.headers["Authorization"]).toBe("Bearer jwt-test");
+    expect(req.headers["x-api-key"]).toBeUndefined();
+  });
+
+  test("apiKey mode emits x-api-key and no Authorization", async () => {
+    const client = new KadoaClient({ apiKey: "tk-test" });
+    const req = await captureRequest(client, () =>
+      client.user.getCurrentUser(),
+    );
+    expect(req.headers["x-api-key"]).toBe("tk-test");
+    expect(req.headers["Authorization"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- `UserService.getCurrentUser` and `EntityResolverService.fetchEntityFields` previously hardcoded `x-api-key: this.client.apiKey`, which emits `x-api-key: ""` in bearer-only mode and breaks auth.
- Auth interceptor in `KadoaClient` is now the single source of truth: it injects `x-api-key` in apiKey mode for direct axios calls, mirroring its existing `Authorization: Bearer` injection in bearer mode.
- The two services drop their manual header set.
- Adds header-assertion tests for both services across apiKey and bearer-only modes, plus interceptor-level coverage for apiKey injection.

Closes [KAD-7302](https://linear.app/kadoa/issue/KAD-7302). Part of [KAD-4039](https://linear.app/kadoa/issue/KAD-4039) — full user-bearer-auth support for `@kadoa/node-sdk`.

## Test plan

- [x] `bun test test/unit` — all 78 unit tests pass
- [x] `bun run typecheck` — clean
- [x] Biome autofix applied to touched files
- [ ] Reviewer: verify bearer-only mode E2E if env available

🤖 Generated with [Claude Code](https://claude.com/claude-code)