### PR TITLE
feat(node-sdk): user bearer auth support (lazy token + interceptor cleanup)

### DIFF
--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -313,6 +313,32 @@ const client = new KadoaClient({
 });
 ```
 
+### User Bearer Auth (Frontend / Per-User Context)
+
+Use a JWT (e.g. Supabase session token) instead of a team API key when the
+SDK should act as the signed-in human user. Pass `bearerToken` as a string,
+or as a function returning the current token — the function runs on each
+request, so a refreshed token is picked up automatically without
+reconstructing the client.
+
+```typescript
+// Static token
+const client = new KadoaClient({ bearerToken: session.access_token });
+
+// Lazy — recommended for frontend integrations with refresh
+const client = new KadoaClient({
+  bearerToken: async () => {
+    const { data } = await supabase.auth.getSession();
+    return data.session?.access_token ?? '';
+  },
+});
+```
+
+**API key vs Bearer token:** use a team API key (`tk-...`) for backend
+service accounts or scripts that act on behalf of a team. Use a bearer
+token (user JWT) when the SDK runs in a logged-in user context (frontend,
+CLI under user login) and requests should authenticate as that user.
+
 ### WebSocket & Realtime Events
 
 Enable realtime notifications using an API key:

--- a/sdks/node/src/client/kadoa-client.ts
+++ b/sdks/node/src/client/kadoa-client.ts
@@ -9,17 +9,19 @@ import type {
 } from "../domains/extraction/services/extraction-builder.service";
 import { Realtime, type RealtimeConfig } from "../domains/realtime";
 import type { SchemasService } from "../domains/schemas/schemas.service";
+import type { TemplatesService } from "../domains/templates/templates.service";
 import type { UserService } from "../domains/user/user.service";
 import type { ValidationDomain } from "../domains/validation/validation.facade";
-import type { TemplatesService } from "../domains/templates/templates.service";
 import type { VariablesService } from "../domains/variables/variables.service";
 import type { WorkflowsCoreService } from "../domains/workflows/workflows-core.service";
 import { PUBLIC_API_URI } from "../runtime/config";
 import { KadoaSdkException } from "../runtime/exceptions";
 import { checkForUpdates } from "../runtime/utils/version-check";
 import { ApiRegistry } from "./api-registry";
+import { resolveBearerToken } from "./resolve-bearer-token";
 import type {
   BearerAuthOptions,
+  BearerTokenProvider,
   KadoaClientConfig,
   KadoaClientStatus,
   NotificationDomain,
@@ -52,7 +54,7 @@ export class KadoaClient {
   private readonly _axiosInstance: AxiosInstance;
   private readonly _baseUrl: string;
   private readonly _apiKey: string;
-  private _bearerToken: string | undefined;
+  private _bearerToken: BearerTokenProvider | undefined;
 
   private _realtime?: Realtime;
   private readonly _extractionBuilderService: ExtractionBuilderService;
@@ -88,11 +90,12 @@ export class KadoaClient {
 
     // Auth interceptor: injects the correct auth header on every request.
     // Runs after per-request headers are set, so it can override them.
-    this._axiosInstance.interceptors.request.use((reqConfig) => {
+    // Async so that function-form bearer tokens can return a Promise.
+    this._axiosInstance.interceptors.request.use(async (reqConfig) => {
       if (this._bearerToken) {
-        // Bearer mode: ensure Authorization header, remove stale x-api-key
+        const token = await resolveBearerToken(this._bearerToken);
         if (!reqConfig.headers["Authorization"]) {
-          reqConfig.headers["Authorization"] = `Bearer ${this._bearerToken}`;
+          reqConfig.headers["Authorization"] = `Bearer ${token}`;
         }
         delete reqConfig.headers["x-api-key"];
       }
@@ -159,9 +162,10 @@ export class KadoaClient {
   /**
    * Update the Bearer token used for authentication.
    * Call this after a Supabase JWT refresh so that subsequent requests
-   * use the new token.
+   * use the new token. Accepts either a string or a function returning
+   * one (sync or async); functions are resolved on each request.
    */
-  setBearerToken(token: string): void {
+  setBearerToken(token: BearerTokenProvider): void {
     this._bearerToken = token;
   }
 
@@ -248,7 +252,9 @@ export class KadoaClient {
     // When opts.bearerToken is provided, override the instance-level auth.
     // Otherwise let the axios auth interceptor handle it.
     const headers: Record<string, string> | undefined = opts?.bearerToken
-      ? { Authorization: `Bearer ${opts.bearerToken}` }
+      ? {
+          Authorization: `Bearer ${await resolveBearerToken(opts.bearerToken)}`,
+        }
       : undefined;
 
     const response = await this._axiosInstance.get("/v5/user", {

--- a/sdks/node/src/client/kadoa-client.ts
+++ b/sdks/node/src/client/kadoa-client.ts
@@ -98,6 +98,10 @@ export class KadoaClient {
           reqConfig.headers["Authorization"] = `Bearer ${token}`;
         }
         delete reqConfig.headers["x-api-key"];
+      } else if (this._apiKey && !reqConfig.headers["x-api-key"]) {
+        // ApiKey mode: ensure x-api-key for direct axios calls that
+        // bypass the generated clients (which set x-api-key via Configuration).
+        reqConfig.headers["x-api-key"] = this._apiKey;
       }
       return reqConfig;
     });

--- a/sdks/node/src/client/resolve-bearer-token.ts
+++ b/sdks/node/src/client/resolve-bearer-token.ts
@@ -1,0 +1,11 @@
+import type { BearerTokenProvider } from "./types";
+
+/**
+ * Resolve a {@link BearerTokenProvider} to its string value.
+ * Awaits a Promise return when the provider is async.
+ */
+export async function resolveBearerToken(
+  provider: BearerTokenProvider,
+): Promise<string> {
+  return typeof provider === "function" ? await provider() : provider;
+}

--- a/sdks/node/src/client/types.ts
+++ b/sdks/node/src/client/types.ts
@@ -17,8 +17,16 @@ export interface TeamInfo {
   adminEmail: string | null;
 }
 
+/**
+ * A Bearer token, or a function that returns one (sync or async).
+ * Functions are invoked on each request, letting integrations supply a
+ * fresh JWT from a session store without re-constructing the client or
+ * calling {@link KadoaClient.setBearerToken} after every refresh.
+ */
+export type BearerTokenProvider = string | (() => string | Promise<string>);
+
 export interface BearerAuthOptions {
-  bearerToken: string;
+  bearerToken: BearerTokenProvider;
 }
 
 export interface KadoaClientStatus {
@@ -33,11 +41,24 @@ export interface KadoaClientConfig {
    */
   apiKey?: string;
   /**
-   * = JWT for Bearer auth. When set, requests send
-   * `Authorization: Bearer <token>` instead of `x-api-key`.
-   * Use {@link KadoaClient.setBearerToken} to update after refresh.
+   * JWT for Bearer auth, or a function returning one (sync or async).
+   * When set, requests send `Authorization: Bearer <token>` instead of
+   * `x-api-key`.
+   *
+   * Passing a function enables lazy resolution: the function is invoked
+   * on each request, so frontend integrations can return the current
+   * Supabase session token without manually calling
+   * {@link KadoaClient.setBearerToken} after every refresh.
+   *
+   * @example
+   * ```ts
+   * new KadoaClient({
+   *   bearerToken: () =>
+   *     supabase.auth.getSession().then((s) => s.data.session?.access_token ?? ""),
+   * });
+   * ```
    */
-  bearerToken?: string;
+  bearerToken?: BearerTokenProvider;
   /**
    * Override the base URL for the public API.
    *

--- a/sdks/node/src/domains/extraction/services/entity-resolver.service.ts
+++ b/sdks/node/src/domains/extraction/services/entity-resolver.service.ts
@@ -142,7 +142,6 @@ export class EntityResolverService {
         headers: {
           "Content-Type": "application/json",
           Accept: "application/json",
-          "x-api-key": this.client.apiKey,
         },
       });
 

--- a/sdks/node/src/domains/user/user.service.ts
+++ b/sdks/node/src/domains/user/user.service.ts
@@ -18,7 +18,6 @@ export class UserService {
     const response = await this.client.axiosInstance.get("/v5/user", {
       baseURL: this.client.baseUrl,
       headers: {
-        "x-api-key": this.client.apiKey,
         "Content-Type": "application/json",
       },
     });

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -22,8 +22,9 @@ export * from "./domains/workflows";
 // Core Client & Configuration
 // ============================================================================
 export {
-  KadoaClient,
   type BearerAuthOptions,
+  type BearerTokenProvider,
+  KadoaClient,
   type KadoaClientConfig,
   type KadoaClientStatus,
   type NotificationDomain,

--- a/sdks/node/src/kadoa-client.ts
+++ b/sdks/node/src/kadoa-client.ts
@@ -1,6 +1,7 @@
 export { KadoaClient } from "./client/kadoa-client";
 export type {
   BearerAuthOptions,
+  BearerTokenProvider,
   KadoaClientConfig,
   KadoaClientStatus,
   NotificationDomain,

--- a/sdks/node/test/unit/entity-resolver.service.test.ts
+++ b/sdks/node/test/unit/entity-resolver.service.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AxiosResponse, InternalAxiosRequestConfig } from "axios";
+import { KadoaClient } from "../../src/client/kadoa-client";
+import { EntityResolverService } from "../../src/domains/extraction/services/entity-resolver.service";
+
+mock.module("../../src/runtime/utils/version-check", () => ({
+  checkForUpdates: () => Promise.resolve(),
+}));
+
+async function captureRequest(
+  client: KadoaClient,
+  call: () => Promise<unknown>,
+): Promise<InternalAxiosRequestConfig> {
+  let captured: InternalAxiosRequestConfig | undefined;
+  client.axiosInstance.defaults.adapter = async (config) => {
+    captured = config;
+    return {
+      data: {
+        success: true,
+        entityPrediction: [{ entity: "Product", fields: [] }],
+      },
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config,
+    } as AxiosResponse;
+  };
+  await call();
+  if (!captured) throw new Error("no request captured");
+  return captured;
+}
+
+describe("EntityResolverService.fetchEntityFields auth headers", () => {
+  test("bearer-only mode emits Authorization and no x-api-key", async () => {
+    const client = new KadoaClient({ bearerToken: "jwt-test" });
+    const resolver = new EntityResolverService(client);
+    const req = await captureRequest(client, () =>
+      resolver.fetchEntityFields({ link: "https://example.com" }),
+    );
+    expect(req.headers["Authorization"]).toBe("Bearer jwt-test");
+    expect(req.headers["x-api-key"]).toBeUndefined();
+  });
+
+  test("apiKey mode emits x-api-key and no Authorization", async () => {
+    const client = new KadoaClient({ apiKey: "tk-test" });
+    const resolver = new EntityResolverService(client);
+    const req = await captureRequest(client, () =>
+      resolver.fetchEntityFields({ link: "https://example.com" }),
+    );
+    expect(req.headers["x-api-key"]).toBe("tk-test");
+    expect(req.headers["Authorization"]).toBeUndefined();
+  });
+});

--- a/sdks/node/test/unit/kadoa-client-auth.test.ts
+++ b/sdks/node/test/unit/kadoa-client-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
-import axios from "axios";
 import type { InternalAxiosRequestConfig } from "axios";
+import axios from "axios";
 import { KadoaClient } from "../../src/client/kadoa-client";
 import { KadoaSdkException } from "../../src/runtime/exceptions";
 
@@ -51,17 +51,16 @@ describe("KadoaClient auth", () => {
      * Runs a request config through all registered request interceptors
      * on the client's axios instance without making a real HTTP call.
      */
-    function runInterceptors(
+    async function runInterceptors(
       client: KadoaClient,
       initial: Partial<InternalAxiosRequestConfig>,
-    ): InternalAxiosRequestConfig {
+    ): Promise<InternalAxiosRequestConfig> {
       // Access the interceptor handlers from axios internals
-      const handlers = (
-        client.axiosInstance.interceptors.request as any
-      ).handlers as Array<{
+      const handlers = (client.axiosInstance.interceptors.request as any)
+        .handlers as Array<{
         fulfilled: (
           config: InternalAxiosRequestConfig,
-        ) => InternalAxiosRequestConfig;
+        ) => InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig>;
       }>;
 
       let config = {
@@ -75,35 +74,35 @@ describe("KadoaClient auth", () => {
 
       for (const handler of handlers) {
         if (handler?.fulfilled) {
-          config = handler.fulfilled(config);
+          config = await handler.fulfilled(config);
         }
       }
       return config;
     }
 
-    test("injects Authorization header when bearerToken is set", () => {
+    test("injects Authorization header when bearerToken is set", async () => {
       const client = new KadoaClient({ bearerToken: "my-jwt" });
-      const result = runInterceptors(client, {});
+      const result = await runInterceptors(client, {});
       expect(result.headers["Authorization"]).toBe("Bearer my-jwt");
     });
 
-    test("removes x-api-key header when bearerToken is set", () => {
+    test("removes x-api-key header when bearerToken is set", async () => {
       const client = new KadoaClient({ bearerToken: "my-jwt" });
-      const result = runInterceptors(client, {
+      const result = await runInterceptors(client, {
         headers: new axios.AxiosHeaders({ "x-api-key": "stale-key" }),
       });
       expect(result.headers["x-api-key"]).toBeUndefined();
     });
 
-    test("does not inject Authorization when only apiKey is used", () => {
+    test("does not inject Authorization when only apiKey is used", async () => {
       const client = new KadoaClient({ apiKey: "tk-test" });
-      const result = runInterceptors(client, {});
+      const result = await runInterceptors(client, {});
       expect(result.headers["Authorization"]).toBeUndefined();
     });
 
-    test("does not override existing Authorization header", () => {
+    test("does not override existing Authorization header", async () => {
       const client = new KadoaClient({ bearerToken: "instance-jwt" });
-      const result = runInterceptors(client, {
+      const result = await runInterceptors(client, {
         headers: new axios.AxiosHeaders({
           Authorization: "Bearer override-jwt",
         }),
@@ -112,17 +111,84 @@ describe("KadoaClient auth", () => {
     });
   });
 
+  describe("lazy bearer token", () => {
+    async function captureFinalRequest(
+      client: KadoaClient,
+      call: () => Promise<unknown>,
+      responseData: unknown = {},
+    ): Promise<InternalAxiosRequestConfig> {
+      let captured: InternalAxiosRequestConfig | undefined;
+      client.axiosInstance.defaults.adapter = async (config) => {
+        captured = config;
+        return {
+          data: responseData,
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config,
+        } as any;
+      };
+      await call();
+      if (!captured) throw new Error("no request captured");
+      return captured;
+    }
+
+    test("resolves sync function per request", async () => {
+      const fn = mock(() => "lazy-jwt");
+      const client = new KadoaClient({ bearerToken: fn });
+      const req = await captureFinalRequest(client, () => client.listTeams());
+      expect(req.headers["Authorization"]).toBe("Bearer lazy-jwt");
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test("resolves async function per request", async () => {
+      const fn = mock(async () => "async-jwt");
+      const client = new KadoaClient({ bearerToken: fn });
+      const req = await captureFinalRequest(client, () => client.listTeams());
+      expect(req.headers["Authorization"]).toBe("Bearer async-jwt");
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test("re-invokes function on each request reflecting updated value", async () => {
+      let token = "v1";
+      const fn = mock(() => token);
+      const client = new KadoaClient({ bearerToken: fn });
+
+      const req1 = await captureFinalRequest(client, () => client.listTeams());
+      expect(req1.headers["Authorization"]).toBe("Bearer v1");
+
+      token = "v2";
+      const req2 = await captureFinalRequest(client, () => client.listTeams());
+      expect(req2.headers["Authorization"]).toBe("Bearer v2");
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    test("setBearerToken accepts a function", async () => {
+      const client = new KadoaClient({ apiKey: "tk-test" });
+      client.setBearerToken(() => "from-setter");
+      const req = await captureFinalRequest(client, () => client.listTeams());
+      expect(req.headers["Authorization"]).toBe("Bearer from-setter");
+    });
+
+    test("listTeams BearerAuthOptions accepts a function", async () => {
+      const client = new KadoaClient({ apiKey: "tk-test" });
+      const req = await captureFinalRequest(client, () =>
+        client.listTeams({ bearerToken: () => "per-call-jwt" }),
+      );
+      expect(req.headers["Authorization"]).toBe("Bearer per-call-jwt");
+    });
+  });
+
   describe("setBearerToken", () => {
-    test("updates token used by interceptor", () => {
+    test("updates token used by interceptor", async () => {
       const client = new KadoaClient({ apiKey: "tk-test" });
 
       // Initially no bearer — interceptor should not set Authorization
-      const handlers = (
-        client.axiosInstance.interceptors.request as any
-      ).handlers as Array<{
+      const handlers = (client.axiosInstance.interceptors.request as any)
+        .handlers as Array<{
         fulfilled: (
           config: InternalAxiosRequestConfig,
-        ) => InternalAxiosRequestConfig;
+        ) => InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig>;
       }>;
 
       const makeConfig = () =>
@@ -132,7 +198,7 @@ describe("KadoaClient auth", () => {
 
       let config = makeConfig();
       for (const h of handlers) {
-        if (h?.fulfilled) config = h.fulfilled(config);
+        if (h?.fulfilled) config = await h.fulfilled(config);
       }
       expect(config.headers["Authorization"]).toBeUndefined();
 
@@ -141,7 +207,7 @@ describe("KadoaClient auth", () => {
 
       config = makeConfig();
       for (const h of handlers) {
-        if (h?.fulfilled) config = h.fulfilled(config);
+        if (h?.fulfilled) config = await h.fulfilled(config);
       }
       expect(config.headers["Authorization"]).toBe("Bearer new-jwt");
     });

--- a/sdks/node/test/unit/kadoa-client-auth.test.ts
+++ b/sdks/node/test/unit/kadoa-client-auth.test.ts
@@ -100,6 +100,20 @@ describe("KadoaClient auth", () => {
       expect(result.headers["Authorization"]).toBeUndefined();
     });
 
+    test("injects x-api-key when only apiKey is used", async () => {
+      const client = new KadoaClient({ apiKey: "tk-test" });
+      const result = await runInterceptors(client, {});
+      expect(result.headers["x-api-key"]).toBe("tk-test");
+    });
+
+    test("does not override existing x-api-key header in apiKey mode", async () => {
+      const client = new KadoaClient({ apiKey: "tk-test" });
+      const result = await runInterceptors(client, {
+        headers: new axios.AxiosHeaders({ "x-api-key": "override-key" }),
+      });
+      expect(result.headers["x-api-key"]).toBe("override-key");
+    });
+
     test("does not override existing Authorization header", async () => {
       const client = new KadoaClient({ bearerToken: "instance-jwt" });
       const result = await runInterceptors(client, {

--- a/sdks/node/test/unit/user.service.test.ts
+++ b/sdks/node/test/unit/user.service.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AxiosResponse, InternalAxiosRequestConfig } from "axios";
+import { KadoaClient } from "../../src/client/kadoa-client";
+
+mock.module("../../src/runtime/utils/version-check", () => ({
+  checkForUpdates: () => Promise.resolve(),
+}));
+
+/**
+ * Capture the final request config (after all interceptors) by stubbing
+ * the axios adapter to short-circuit the network call with a fake response.
+ */
+async function captureRequest(
+  client: KadoaClient,
+  call: () => Promise<unknown>,
+  response: unknown = {
+    userId: "u1",
+    email: "u@example.com",
+    featureFlags: [],
+  },
+): Promise<InternalAxiosRequestConfig> {
+  let captured: InternalAxiosRequestConfig | undefined;
+  client.axiosInstance.defaults.adapter = async (config) => {
+    captured = config;
+    return {
+      data: response,
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config,
+    } as AxiosResponse;
+  };
+  await call();
+  if (!captured) throw new Error("no request captured");
+  return captured;
+}
+
+describe("UserService.getCurrentUser auth headers", () => {
+  test("bearer-only mode emits Authorization and no x-api-key", async () => {
+    const client = new KadoaClient({ bearerToken: "jwt-test" });
+    const req = await captureRequest(client, () =>
+      client.user.getCurrentUser(),
+    );
+    expect(req.headers["Authorization"]).toBe("Bearer jwt-test");
+    expect(req.headers["x-api-key"]).toBeUndefined();
+  });
+
+  test("apiKey mode emits x-api-key and no Authorization", async () => {
+    const client = new KadoaClient({ apiKey: "tk-test" });
+    const req = await captureRequest(client, () =>
+      client.user.getCurrentUser(),
+    );
+    expect(req.headers["x-api-key"]).toBe("tk-test");
+    expect(req.headers["Authorization"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Combined fix for [KAD-7302](https://linear.app/kadoa/issue/KAD-7302) + [KAD-7303](https://linear.app/kadoa/issue/KAD-7303), addressing the [KAD-4039](https://linear.app/kadoa/issue/KAD-4039) MVP.

### Lazy bearer token (KAD-7303, functional)

- `KadoaClientConfig.bearerToken` and `BearerAuthOptions.bearerToken` now accept `string | (() => string | Promise<string>)`.
- The axios auth interceptor (now async) and `listTeams()` resolve the provider on each request — frontend integrations can return a fresh JWT from a refresh-aware store (e.g. Supabase) without re-constructing the client or calling `setBearerToken()` after every refresh.
- `setBearerToken()` accepts the same union.
- README documents the new lazy form and clarifies API key vs user bearer token semantics.

### Interceptor consolidation (KAD-7302, refactor)

- `UserService.getCurrentUser` and `EntityResolverService.fetchEntityFields` no longer hardcode `x-api-key` headers — auth interceptor is the single source of truth.
- Interceptor injects `x-api-key` in apiKey mode for direct axios calls that bypass generated clients.
- Existing bearer-mode behavior unchanged (interceptor was already stripping empty `x-api-key` and adding Authorization), so no behavior bug fix — just dead-code removal + convention enforcement.

## Frontend example

```ts
const client = new KadoaClient({
  bearerToken: async () => {
    const { data } = await supabase.auth.getSession();
    return data.session?.access_token ?? '';
  },
});
```

## Test plan

- [x] `bun test test/unit` — 97 unit tests pass (interceptor + services + lazy bearer)
- [x] `bun run typecheck` — clean
- [x] Biome autofix applied to touched files
- [ ] Reviewer: confirm no regressions in apiKey-mode flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)