### PR TITLE
chore: remove navigation mode parameter (kad-7300)

### DIFF
--- a/sdks/node/src/domains/extraction/extraction.acl.ts
+++ b/sdks/node/src/domains/extraction/extraction.acl.ts
@@ -17,20 +17,14 @@ import type {
   V4WorkflowsWorkflowIdMetadataPutRequestMonitoringFieldsInner,
   V4WorkflowsWorkflowIdMetadataPutRequestMonitoringFieldsInnerOperatorEnum,
   WorkflowWithExistingSchemaIntervalEnum,
-  WorkflowWithExistingSchemaNavigationModeEnum,
 } from "../../generated";
 import { DataFieldDataTypeEnum } from "../../generated";
-import type {
-  GetWorkflowResponse,
-  MonitoringConfig,
-  WorkflowsApiInterface,
-} from "../workflows/workflows.acl";
+import type { GetWorkflowResponse, MonitoringConfig, WorkflowsApiInterface } from "../workflows/workflows.acl";
 
 /**
  * Data pagination metadata.
  */
-export type DataPagination =
-  V4WorkflowsWorkflowIdDataGet200ResponseOneOfPagination;
+export type DataPagination = V4WorkflowsWorkflowIdDataGet200ResponseOneOfPagination;
 
 /**
  * Workflow data response.
@@ -44,10 +38,7 @@ export type WorkflowDataResponse = V4WorkflowsWorkflowIdDataGet200Response;
 export const DataSortOrder = {
   Asc: "asc",
   Desc: "desc",
-} as const satisfies Record<
-  keyof typeof V4WorkflowsWorkflowIdDataGetOrderEnum,
-  V4WorkflowsWorkflowIdDataGetOrderEnum
->;
+} as const satisfies Record<keyof typeof V4WorkflowsWorkflowIdDataGetOrderEnum, V4WorkflowsWorkflowIdDataGetOrderEnum>;
 
 export type DataSortOrder = (typeof DataSortOrder)[keyof typeof DataSortOrder];
 
@@ -80,10 +71,7 @@ const CanonicalSchemaFieldDataType = {
   Link: DataFieldDataTypeEnum.Link,
   Object: DataFieldDataTypeEnum.Object,
   Array: DataFieldDataTypeEnum.Array,
-} as const satisfies Record<
-  keyof typeof DataFieldDataTypeEnum,
-  DataFieldDataTypeEnum
->;
+} as const satisfies Record<keyof typeof DataFieldDataTypeEnum, DataFieldDataTypeEnum>;
 
 /**
  * Curated field data type enum exposed by the SDK.
@@ -97,16 +85,11 @@ export const SchemaFieldDataType = {
   Url: DataFieldDataTypeEnum.Link,
 } as const satisfies Record<string, DataFieldDataTypeEnum>;
 
-export type SchemaFieldDataType =
-  (typeof SchemaFieldDataType)[keyof typeof SchemaFieldDataType];
+export type SchemaFieldDataType = (typeof SchemaFieldDataType)[keyof typeof SchemaFieldDataType];
 
 export type SchemaField = DataField | ClassificationField;
 
-export type NavigationMode =
-  (typeof WorkflowWithExistingSchemaNavigationModeEnum)[keyof typeof WorkflowWithExistingSchemaNavigationModeEnum];
-
-export type DataTypeInternal =
-  (typeof DataFieldDataTypeEnum)[keyof typeof DataFieldDataTypeEnum];
+export type DataTypeInternal = (typeof DataFieldDataTypeEnum)[keyof typeof DataFieldDataTypeEnum];
 
 export type DataType = Exclude<
   DataTypeInternal,
@@ -128,10 +111,9 @@ export type WorkflowInterval =
 export type MonitoringOperator =
   (typeof V4WorkflowsWorkflowIdMetadataPutRequestMonitoringFieldsInnerOperatorEnum)[keyof typeof V4WorkflowsWorkflowIdMetadataPutRequestMonitoringFieldsInnerOperatorEnum];
 
-export type MonitoringField =
-  V4WorkflowsWorkflowIdMetadataPutRequestMonitoringFieldsInner & {
-    isKeyField?: boolean;
-  };
+export type MonitoringField = V4WorkflowsWorkflowIdMetadataPutRequestMonitoringFieldsInner & {
+  isKeyField?: boolean;
+};
 
 export type LocationConfig = Location;
 
@@ -149,9 +131,7 @@ export type RawFormat = "HTML" | "MARKDOWN" | "PAGE_URL";
  */
 export type MetadataKey = RawFormat;
 
-export type FieldType =
-  | ClassificationFieldFieldTypeEnum
-  | DataFieldFieldTypeEnum;
+export type FieldType = ClassificationFieldFieldTypeEnum | DataFieldFieldTypeEnum;
 
 export type WorkflowMonitoringConfig = MonitoringConfig;
 

--- a/sdks/node/src/domains/extraction/services/entity-resolver.service.ts
+++ b/sdks/node/src/domains/extraction/services/entity-resolver.service.ts
@@ -24,7 +24,6 @@ export interface EntityResponse {
 export interface EntityRequestOptions {
   link: string;
   location?: LocationConfig;
-  navigationMode?: string;
   selectorMode?: boolean;
 }
 
@@ -33,10 +32,7 @@ export interface ResolvedEntity {
   fields: SchemaField[];
 }
 
-export type EntityConfig =
-  | "ai-detection"
-  | { schemaId: string }
-  | { name?: string; fields: SchemaField[] };
+export type EntityConfig = "ai-detection" | { schemaId: string } | { name?: string; fields: SchemaField[] };
 
 export const ENTITY_API_ENDPOINT = "/v4/entity";
 
@@ -66,7 +62,6 @@ export class EntityResolverService {
     options?: {
       link?: string;
       location?: LocationConfig;
-      navigationMode?: string;
       selectorMode?: boolean;
     },
   ): Promise<ResolvedEntity> {
@@ -82,7 +77,6 @@ export class EntityResolverService {
       const entityPrediction = await this.fetchEntityFields({
         link: options.link,
         location: options.location,
-        navigationMode: options.navigationMode,
         selectorMode: options.selectorMode ?? false,
       });
 
@@ -94,16 +88,13 @@ export class EntityResolverService {
     } else if (entityConfig) {
       if ("schemaId" in entityConfig) {
         // Fetch schema from API to get entity and fields
-        const schema = await this.schemasService.getSchema(
-          entityConfig.schemaId,
-        );
+        const schema = await this.schemasService.getSchema(entityConfig.schemaId);
         // Backend may include transform/placeholder variants in the response
         // union; the SDK only consumes structured/classification fields.
         return {
           entity: schema.entity ?? undefined,
           fields: (schema.schema ?? []).filter(
-            (f): f is SchemaField =>
-              f.fieldType === "SCHEMA" || f.fieldType === "CLASSIFICATION",
+            (f): f is SchemaField => f.fieldType === "SCHEMA" || f.fieldType === "CLASSIFICATION",
           ),
         };
       } else if ("fields" in entityConfig) {
@@ -129,29 +120,22 @@ export class EntityResolverService {
    * @param options Request options including the link to analyze
    * @returns EntityPrediction containing the detected entity type and fields
    */
-  async fetchEntityFields(
-    options: EntityRequestOptions,
-  ): Promise<EntityPrediction> {
+  async fetchEntityFields(options: EntityRequestOptions): Promise<EntityPrediction> {
     this.validateEntityOptions(options);
 
     const url = `${this.client.baseUrl}${ENTITY_API_ENDPOINT}`;
     const requestBody: EntityRequestOptions = options;
 
-    const response: AxiosResponse<EntityResponse> =
-      await this.client.axiosInstance.post(url, requestBody, {
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-      });
+    const response: AxiosResponse<EntityResponse> = await this.client.axiosInstance.post(url, requestBody, {
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+    });
 
     const data = response.data;
 
-    if (
-      !data.success ||
-      !data.entityPrediction ||
-      data.entityPrediction.length === 0
-    ) {
+    if (!data.success || !data.entityPrediction || data.entityPrediction.length === 0) {
       throw new KadoaSdkException(ERROR_MESSAGES.NO_PREDICTIONS, {
         code: "NOT_FOUND",
         details: {

--- a/sdks/node/src/domains/extraction/services/extraction-builder.service.ts
+++ b/sdks/node/src/domains/extraction/services/extraction-builder.service.ts
@@ -1,13 +1,7 @@
 import assert from "node:assert";
-import {
-  KadoaHttpException,
-  KadoaSdkException,
-} from "../../../runtime/exceptions";
+import { KadoaHttpException, KadoaSdkException } from "../../../runtime/exceptions";
 import { logger } from "../../../runtime/logger";
-import type {
-  NotificationOptions,
-  NotificationSetupService,
-} from "../../notifications/notification-setup.service";
+import type { NotificationOptions, NotificationSetupService } from "../../notifications/notification-setup.service";
 import { SchemaBuilder } from "../../schemas/schema-builder";
 import type { GetWorkflowResponse } from "../../workflows/workflows.acl";
 import type { WorkflowsCoreService } from "../../workflows/workflows-core.service";
@@ -18,43 +12,24 @@ import type {
   WorkflowInterval,
   WorkflowMonitoringConfig,
 } from "../extraction.acl";
-import type {
-  DataFetcherService,
-  FetchDataResult,
-} from "./data-fetcher.service";
+import type { DataFetcherService, FetchDataResult } from "./data-fetcher.service";
 import type { EntityConfig } from "./entity-resolver.service";
 
 const debug = logger.extraction;
-const DEFAULT_AGENTIC_PROMPT =
-  "extract all the data for the main entity of this page";
+const DEFAULT_AGENTIC_PROMPT = "extract all the data for the main entity of this page";
 const BUILD_NOT_READY_ERROR = "No completed build. Build the project first.";
-const TERMINAL_RUN_STATES = new Set([
-  "FINISHED",
-  "SUCCESS",
-  "FAILED",
-  "ERROR",
-  "STOPPED",
-  "CANCELLED",
-]);
+const TERMINAL_RUN_STATES = new Set(["FINISHED", "SUCCESS", "FAILED", "ERROR", "STOPPED", "CANCELLED"]);
 
 function getFieldName(field: SchemaField): string | undefined {
-  return "name" in field && typeof field.name === "string"
-    ? field.name
-    : undefined;
+  return "name" in field && typeof field.name === "string" ? field.name : undefined;
 }
 
-function buildAgenticPrompt(params: {
-  entity?: string;
-  fields: Array<SchemaField>;
-  userPrompt?: string;
-}): string {
+function buildAgenticPrompt(params: { entity?: string; fields: Array<SchemaField>; userPrompt?: string }): string {
   if (params.userPrompt) {
     return params.userPrompt;
   }
 
-  const fieldNames = params.fields
-    .map((field) => getFieldName(field))
-    .filter((name): name is string => Boolean(name));
+  const fieldNames = params.fields.map((field) => getFieldName(field)).filter((name): name is string => Boolean(name));
 
   if (fieldNames.length === 0) {
     return DEFAULT_AGENTIC_PROMPT;
@@ -91,9 +66,7 @@ export interface PreparedExtraction {
 
   withMonitoring: (options: WorkflowMonitoringConfig) => PreparedExtraction;
 
-  setInterval: (
-    options: { interval: WorkflowInterval } | { schedules: string[] },
-  ) => PreparedExtraction;
+  setInterval: (options: { interval: WorkflowInterval } | { schedules: string[] }) => PreparedExtraction;
 
   bypassPreview: () => PreparedExtraction;
 
@@ -138,12 +111,8 @@ export interface SubmittedExtraction {
 export interface FinishedExtraction {
   jobId: string;
 
-  fetchData: (
-    options: Omit<FetchDataOptions, "workflowId" | "runId">,
-  ) => Promise<FetchDataResult>;
-  fetchAllData: (
-    options: Omit<FetchDataOptions, "workflowId" | "runId" | "page" | "limit">,
-  ) => Promise<object[]>;
+  fetchData: (options: Omit<FetchDataOptions, "workflowId" | "runId">) => Promise<FetchDataResult>;
+  fetchAllData: (options: Omit<FetchDataOptions, "workflowId" | "runId" | "page" | "limit">) => Promise<object[]>;
 }
 
 export class ExtractionBuilderService {
@@ -229,9 +198,7 @@ export class ExtractionBuilderService {
     return this;
   }
 
-  withNotifications(
-    options: Omit<NotificationOptions, "workflowId">,
-  ): PreparedExtraction {
+  withNotifications(options: Omit<NotificationOptions, "workflowId">): PreparedExtraction {
     this._notificationOptions = options;
 
     return this;
@@ -248,9 +215,7 @@ export class ExtractionBuilderService {
     return this;
   }
 
-  setInterval(
-    options: { interval: WorkflowInterval } | { schedules: string[] },
-  ): PreparedExtraction {
+  setInterval(options: { interval: WorkflowInterval } | { schedules: string[] }): PreparedExtraction {
     assert(this._options, "Options are not set");
     if ("interval" in options) {
       this._options.interval = options.interval;
@@ -279,12 +244,8 @@ export class ExtractionBuilderService {
     const { urls, name, description, entity } = this.options;
 
     const resolvedEntity: { entity?: string; fields: Array<SchemaField> } = {
-      entity:
-        typeof entity === "object" && "name" in entity
-          ? entity.name
-          : undefined,
-      fields:
-        typeof entity === "object" && "fields" in entity ? entity.fields : [],
+      entity: typeof entity === "object" && "name" in entity ? entity.name : undefined,
+      fields: typeof entity === "object" && "fields" in entity ? entity.fields : [],
     };
 
     this._userPrompt = buildAgenticPrompt({
@@ -294,17 +255,13 @@ export class ExtractionBuilderService {
     });
     this._options.userPrompt = this._userPrompt;
 
-    const schemaId =
-      typeof entity === "object" && "schemaId" in entity
-        ? entity.schemaId
-        : undefined;
+    const schemaId = typeof entity === "object" && "schemaId" in entity ? entity.schemaId : undefined;
     const hasSchemaId = Boolean(schemaId);
 
     const workflow = await this.workflowsCoreService.create({
       urls,
       name,
       description,
-      navigationMode: "agentic-navigation",
       monitoring: this._monitoringOptions,
       ...(hasSchemaId
         ? {
@@ -332,17 +289,12 @@ export class ExtractionBuilderService {
     return this;
   }
 
-  async waitForReady(
-    options?: WaitForReadyOptions,
-  ): Promise<GetWorkflowResponse> {
+  async waitForReady(options?: WaitForReadyOptions): Promise<GetWorkflowResponse> {
     assert(this._workflowId, "Workflow ID is not set");
     const targetState = options?.targetState ?? "PREVIEW";
 
     const current = await this.workflowsCoreService.get(this._workflowId);
-    if (
-      current.state === targetState ||
-      (targetState === "PREVIEW" && current.state === "ACTIVE")
-    ) {
+    if (current.state === targetState || (targetState === "PREVIEW" && current.state === "ACTIVE")) {
       return current;
     }
 
@@ -380,10 +332,7 @@ export class ExtractionBuilderService {
     debug("Job started: %O", startedJob);
     this._jobId = startedJob.jobId;
 
-    const finishedJob = await this.workflowsCoreService.waitForJobCompletion(
-      this._workflowId,
-      startedJob.jobId,
-    );
+    const finishedJob = await this.workflowsCoreService.waitForJobCompletion(this._workflowId, startedJob.jobId);
     debug("Job finished: %O", finishedJob);
 
     return this;
@@ -420,9 +369,7 @@ export class ExtractionBuilderService {
     };
   }
 
-  async fetchData(
-    options: Omit<FetchDataOptions, "workflowId" | "runId">,
-  ): Promise<FetchDataResult> {
+  async fetchData(options: Omit<FetchDataOptions, "workflowId" | "runId">): Promise<FetchDataResult> {
     assert(this._workflowId, "Workflow ID is not set");
     assert(this._jobId, "Job ID is not set");
     return this.dataFetcherService.fetchData({
@@ -434,9 +381,7 @@ export class ExtractionBuilderService {
     });
   }
 
-  async fetchAllData(
-    options: Omit<FetchDataOptions, "workflowId" | "runId" | "page" | "limit">,
-  ): Promise<object[]> {
+  async fetchAllData(options: Omit<FetchDataOptions, "workflowId" | "runId" | "page" | "limit">): Promise<object[]> {
     assert(this._jobId, "Job ID is not set");
     assert(this._workflowId, "Workflow ID is not set");
     return this.dataFetcherService.fetchAllData({
@@ -446,10 +391,7 @@ export class ExtractionBuilderService {
     });
   }
 
-  private async startOrReuseWorkflowRun(
-    workflowId: string,
-    input: RunWorkflowOptions,
-  ) {
+  private async startOrReuseWorkflowRun(workflowId: string, input: RunWorkflowOptions) {
     // Some agentic workflows already have an active job by the time create()
     // returns, so reuse that run instead of issuing a duplicate /run request.
     const currentJob = await this.findActiveWorkflowJob(workflowId);
@@ -467,10 +409,7 @@ export class ExtractionBuilderService {
 
       const recoveredJob = await this.waitForWorkflowJob(workflowId);
       if (recoveredJob) {
-        debug(
-          "Recovered active workflow job after run rejection: %O",
-          recoveredJob,
-        );
+        debug("Recovered active workflow job after run rejection: %O", recoveredJob);
         return recoveredJob;
       }
 
@@ -523,8 +462,6 @@ export class ExtractionBuilderService {
       return responseBody.error.includes(BUILD_NOT_READY_ERROR);
     }
 
-    return typeof error.message === "string"
-      ? error.message.includes(BUILD_NOT_READY_ERROR)
-      : false;
+    return typeof error.message === "string" ? error.message.includes(BUILD_NOT_READY_ERROR) : false;
   }
 }

--- a/sdks/node/src/domains/extraction/services/extraction.service.ts
+++ b/sdks/node/src/domains/extraction/services/extraction.service.ts
@@ -11,12 +11,7 @@ import type {
   NotificationSettingsService,
   NotificationSetupService,
 } from "../../notifications";
-import type {
-  GetJobResponse,
-  RunWorkflowRequest,
-  RunWorkflowResponse,
-  WorkflowsCoreService,
-} from "../../workflows";
+import type { GetJobResponse, RunWorkflowRequest, RunWorkflowResponse, WorkflowsCoreService } from "../../workflows";
 import type {
   FetchDataOptions,
   LocationConfig,
@@ -25,12 +20,7 @@ import type {
   WorkflowInterval,
   WorkflowMonitoringConfig,
 } from "../extraction.acl";
-import type {
-  DataFetcherService,
-  ExportDataOptions,
-  ExportDataResult,
-  FetchDataResult,
-} from "./data-fetcher.service";
+import type { DataFetcherService, ExportDataOptions, ExportDataResult, FetchDataResult } from "./data-fetcher.service";
 import type { EntityConfig } from "./entity-resolver.service";
 
 const debug = logger.extraction;
@@ -74,27 +64,18 @@ export interface SubmitExtractionResult {
 
 // Use TERMINAL_RUN_STATES from WorkflowsCoreService for consistency
 const SUCCESSFUL_RUN_STATES = new Set(["FINISHED", "SUCCESS"]);
-const DEFAULT_AGENTIC_PROMPT =
-  "extract all the data for the main entity of this page";
+const DEFAULT_AGENTIC_PROMPT = "extract all the data for the main entity of this page";
 
 function getFieldName(field: SchemaField): string | undefined {
-  return "name" in field && typeof field.name === "string"
-    ? field.name
-    : undefined;
+  return "name" in field && typeof field.name === "string" ? field.name : undefined;
 }
 
-function buildAgenticPrompt(params: {
-  entity?: string;
-  fields: Array<SchemaField>;
-  userPrompt?: string;
-}): string {
+function buildAgenticPrompt(params: { entity?: string; fields: Array<SchemaField>; userPrompt?: string }): string {
   if (params.userPrompt) {
     return params.userPrompt;
   }
 
-  const fieldNames = params.fields
-    .map((field) => getFieldName(field))
-    .filter((name): name is string => Boolean(name));
+  const fieldNames = params.fields.map((field) => getFieldName(field)).filter((name): name is string => Boolean(name));
 
   if (fieldNames.length === 0) {
     return DEFAULT_AGENTIC_PROMPT;
@@ -108,10 +89,7 @@ function buildAgenticPrompt(params: {
   return `extract all records from this page and return these fields: ${fieldList}`;
 }
 
-export const DEFAULT_OPTIONS: Omit<
-  ExtractionOptionsInternal,
-  "urls" | "entity" | "fields" | "description"
-> = {
+export const DEFAULT_OPTIONS: Omit<ExtractionOptionsInternal, "urls" | "entity" | "fields" | "description"> = {
   mode: "run",
   pollingInterval: 5000,
   maxWaitTime: 300000,
@@ -148,28 +126,16 @@ export class ExtractionService {
   /**
    * Trigger a workflow run without waiting for completion.
    */
-  async runJob(
-    workflowId: string,
-    input: RunWorkflowRequest,
-  ): Promise<RunWorkflowResponse> {
+  async runJob(workflowId: string, input: RunWorkflowRequest): Promise<RunWorkflowResponse> {
     return await this.workflowsCoreService.runWorkflow(workflowId, input);
   }
 
   /**
    * Trigger a workflow run and wait for the job to complete.
    */
-  async runJobAndWait(
-    workflowId: string,
-    input: RunWorkflowRequest,
-  ): Promise<GetJobResponse> {
-    const result = await this.workflowsCoreService.runWorkflow(
-      workflowId,
-      input,
-    );
-    return await this.workflowsCoreService.waitForJobCompletion(
-      workflowId,
-      result.jobId || "",
-    );
+  async runJobAndWait(workflowId: string, input: RunWorkflowRequest): Promise<GetJobResponse> {
+    const result = await this.workflowsCoreService.runWorkflow(workflowId, input);
+    return await this.workflowsCoreService.waitForJobCompletion(workflowId, result.jobId || "");
   }
 
   /**
@@ -199,39 +165,29 @@ export class ExtractionService {
   /**
    * Iterate through extraction data pages.
    */
-  fetchDataPages(
-    options: FetchDataOptions,
-  ): AsyncGenerator<FetchDataResult, void, unknown> {
+  fetchDataPages(options: FetchDataOptions): AsyncGenerator<FetchDataResult, void, unknown> {
     return this.dataFetcherService.fetchDataPages(options);
   }
 
   /**
    * List notification channels for a workflow.
    */
-  async getNotificationChannels(
-    workflowId: string,
-  ): Promise<NotificationChannel[]> {
+  async getNotificationChannels(workflowId: string): Promise<NotificationChannel[]> {
     return await this.notificationChannelsService.listChannels({ workflowId });
   }
 
   /**
    * List notification settings for a workflow.
    */
-  async getNotificationSettings(
-    workflowId: string,
-  ): Promise<NotificationSettings[]> {
+  async getNotificationSettings(workflowId: string): Promise<NotificationSettings[]> {
     return await this.notificationSettingsService.listSettings({ workflowId });
   }
 
   /**
    * execute extraction workflow
    */
-  private async executeExtraction(
-    options: ExtractionOptions & { mode?: "run" },
-  ): Promise<ExtractionResult>;
-  private async executeExtraction(
-    options: ExtractionOptions & { mode: "submit" },
-  ): Promise<SubmitExtractionResult>;
+  private async executeExtraction(options: ExtractionOptions & { mode?: "run" }): Promise<ExtractionResult>;
+  private async executeExtraction(options: ExtractionOptions & { mode: "submit" }): Promise<SubmitExtractionResult>;
   private async executeExtraction(
     options: ExtractionOptions & { mode?: "run" | "submit" },
   ): Promise<ExtractionResult | SubmitExtractionResult> {
@@ -260,14 +216,8 @@ export class ExtractionService {
 
     const entityConfig = options.entity;
     const resolvedEntity: { entity?: string; fields: Array<SchemaField> } = {
-      entity:
-        typeof entityConfig === "object" && "name" in entityConfig
-          ? entityConfig.name
-          : undefined,
-      fields:
-        typeof entityConfig === "object" && "fields" in entityConfig
-          ? entityConfig.fields
-          : [],
+      entity: typeof entityConfig === "object" && "name" in entityConfig ? entityConfig.name : undefined,
+      fields: typeof entityConfig === "object" && "fields" in entityConfig ? entityConfig.fields : [],
     };
 
     const hasNotifications = !!config.notifications;
@@ -280,11 +230,8 @@ export class ExtractionService {
 
     const workflowRequest = {
       ...config,
-      navigationMode: "agentic-navigation" as const,
       fields: resolvedEntity.fields,
-      ...(resolvedEntity.entity !== undefined
-        ? { entity: resolvedEntity.entity }
-        : {}),
+      ...(resolvedEntity.entity !== undefined ? { entity: resolvedEntity.entity } : {}),
       userPrompt,
     };
 
@@ -326,17 +273,14 @@ export class ExtractionService {
       data = dataPage.data;
       pagination = dataPage.pagination;
     } else {
-      throw new KadoaSdkException(
-        `${ERROR_MESSAGES.WORKFLOW_UNEXPECTED_STATUS}: ${workflow.runState}`,
-        {
-          code: "INTERNAL_ERROR",
-          details: {
-            workflowId,
-            runState: workflow.runState,
-            state: workflow.state,
-          },
+      throw new KadoaSdkException(`${ERROR_MESSAGES.WORKFLOW_UNEXPECTED_STATUS}: ${workflow.runState}`, {
+        code: "INTERNAL_ERROR",
+        details: {
+          workflowId,
+          runState: workflow.runState,
+          state: workflow.state,
         },
-      );
+      });
     }
 
     return {
@@ -378,17 +322,14 @@ export class ExtractionService {
       data = dataPage.data;
       pagination = dataPage.pagination;
     } else {
-      throw new KadoaSdkException(
-        `${ERROR_MESSAGES.WORKFLOW_UNEXPECTED_STATUS}: ${workflow.runState}`,
-        {
-          code: "INTERNAL_ERROR",
-          details: {
-            workflowId,
-            runState: workflow.runState,
-            state: workflow.state,
-          },
+      throw new KadoaSdkException(`${ERROR_MESSAGES.WORKFLOW_UNEXPECTED_STATUS}: ${workflow.runState}`, {
+        code: "INTERNAL_ERROR",
+        details: {
+          workflowId,
+          runState: workflow.runState,
+          state: workflow.state,
         },
-      );
+      });
     }
 
     return {

--- a/sdks/node/src/domains/workflows/workflows-core.service.ts
+++ b/sdks/node/src/domains/workflows/workflows-core.service.ts
@@ -1,18 +1,9 @@
 import { KadoaSdkException } from "../../runtime/exceptions";
 import { ERROR_MESSAGES } from "../../runtime/exceptions/base.exception";
-import type { TemplatesService } from "../templates/templates.service";
 import { logger } from "../../runtime/logger";
-import {
-  type PollingOptions,
-  pollUntil,
-  validateAdditionalData,
-} from "../../runtime/utils";
-import type {
-  LocationConfig,
-  NavigationMode,
-  SchemaField,
-  WorkflowInterval,
-} from "../extraction/extraction.acl";
+import { type PollingOptions, pollUntil, validateAdditionalData } from "../../runtime/utils";
+import type { LocationConfig, SchemaField, WorkflowInterval } from "../extraction/extraction.acl";
+import type { TemplatesService } from "../templates/templates.service";
 import {
   type GetJobResponse,
   type GetWorkflowResponse,
@@ -68,7 +59,7 @@ export interface CreateWorkflowInput {
   /**
    * Instantiate a workflow from a published template. When set, only `urls`
    * is required — `userPrompt`, `entity`, `fields`, `schemaId`,
-   * `monitoring`, and `navigationMode` must NOT be supplied; they are
+   * `monitoring` must NOT be supplied; they are
    * inherited from the resolved template version.
    *
    * If `templateVersion` is omitted, the SDK resolves the template's
@@ -81,12 +72,6 @@ export interface CreateWorkflowInput {
    * `templateId` is set and this field is omitted.
    */
   templateVersion?: number;
-  /**
-   * @deprecated The backend no longer accepts a `navigationMode` field —
-   * navigation is inferred from `userPrompt`. Kept on the SDK input shape
-   * for backwards compatibility; the value is ignored.
-   */
-  navigationMode?: NavigationMode;
   /**
    * @deprecated The backend no longer accepts an `autoStart` field on create.
    * Kept on the SDK input shape for backwards compatibility; the value is ignored.
@@ -130,7 +115,6 @@ export class WorkflowsCoreService {
       if (input.fields != null) conflicting.push("fields");
       if (input.schemaId != null) conflicting.push("schemaId");
       if (input.monitoring != null) conflicting.push("monitoring");
-      if (input.navigationMode != null) conflicting.push("navigationMode");
       if (conflicting.length > 0) {
         throw new KadoaSdkException(
           `Fields are defined by the template and cannot be supplied when creating from a template: ${conflicting.join(", ")}`,
@@ -141,13 +125,10 @@ export class WorkflowsCoreService {
         );
       }
     } else if (!input.userPrompt) {
-      throw new KadoaSdkException(
-        "userPrompt is required to create a workflow",
-        {
-          code: "VALIDATION_ERROR",
-          details: { urls: input.urls },
-        },
-      );
+      throw new KadoaSdkException("userPrompt is required to create a workflow", {
+        code: "VALIDATION_ERROR",
+        details: { urls: input.urls },
+      });
     }
 
     const domainName = new URL(input.urls[0]).hostname;
@@ -155,8 +136,7 @@ export class WorkflowsCoreService {
     let request: PromptWorkflow | WorkflowFromTemplate;
     if (isFromTemplate) {
       const templateId = input.templateId as string;
-      const templateVersion =
-        input.templateVersion ?? (await this.resolveLatestVersion(templateId));
+      const templateVersion = input.templateVersion ?? (await this.resolveLatestVersion(templateId));
 
       request = {
         urls: input.urls,
@@ -177,17 +157,11 @@ export class WorkflowsCoreService {
         ...(input.limit != null && { limit: input.limit }),
       } as WorkflowFromTemplate;
     } else {
-      // The OpenAPI spec dropped `navigationMode` when it consolidated the
-      // create-workflow body into `PublicWorkflowCreateRequest`, but the
-      // public-api handler still uses `detectWorkflowType` to route based
-      // on it (with a fallback that misroutes prompt-based workflows). Send
-      // it explicitly so the backend dispatches to the agentic branch.
       request = {
         urls: input.urls,
         name: input.name ?? domainName,
         description: input.description,
         userPrompt: input.userPrompt,
-        navigationMode: "agentic-navigation",
         schemaId: input.schemaId,
         ...(input.entity != null && { entity: input.entity }),
         fields: input.fields,
@@ -267,10 +241,7 @@ export class WorkflowsCoreService {
    * (UI/API/SDK/MCP/CLI/SYSTEM), and full before/after snapshots for UPDATE
    * operations. CREATE entries have null `previousValue`/`newValue`.
    */
-  async getAuditLog(
-    id: WorkflowId,
-    options?: WorkflowAuditLogOptions,
-  ): Promise<WorkflowAuditLogResponse> {
+  async getAuditLog(id: WorkflowId, options?: WorkflowAuditLogOptions): Promise<WorkflowAuditLogResponse> {
     const response = await this.workflowsApi.v5WorkflowsWorkflowIdAuditlogGet({
       workflowId: id,
       page: options?.page,
@@ -285,10 +256,7 @@ export class WorkflowsCoreService {
     });
   }
 
-  async update(
-    id: WorkflowId,
-    input: UpdateWorkflowRequest,
-  ): Promise<UpdateWorkflowResponse> {
+  async update(id: WorkflowId, input: UpdateWorkflowRequest): Promise<UpdateWorkflowResponse> {
     validateAdditionalData(input.additionalData);
 
     const response = await this.workflowsApi.v4WorkflowsWorkflowIdMetadataPut({
@@ -313,10 +281,7 @@ export class WorkflowsCoreService {
   /**
    * Wait for a workflow to reach the target state or a terminal state if no target state is provided
    */
-  async wait(
-    id: WorkflowId,
-    options?: WaitOptions,
-  ): Promise<GetWorkflowResponse> {
+  async wait(id: WorkflowId, options?: WaitOptions): Promise<GetWorkflowResponse> {
     const result = await pollUntil(
       async () => {
         const current = await this.get(id);
@@ -332,11 +297,7 @@ export class WorkflowsCoreService {
         }
 
         // Check for terminal states
-        if (
-          current.runState &&
-          TERMINAL_RUN_STATES.has(current.runState.toUpperCase()) &&
-          current.state !== "QUEUED"
-        ) {
+        if (current.runState && TERMINAL_RUN_STATES.has(current.runState.toUpperCase()) && current.state !== "QUEUED") {
           return true;
         }
 
@@ -351,10 +312,7 @@ export class WorkflowsCoreService {
   /**
    * Run a workflow with variables and optional limit
    */
-  async runWorkflow(
-    workflowId: WorkflowId,
-    input: RunWorkflowRequest,
-  ): Promise<RunWorkflowResponse> {
+  async runWorkflow(workflowId: WorkflowId, input: RunWorkflowRequest): Promise<RunWorkflowResponse> {
     const response = await this.workflowsApi.v4WorkflowsWorkflowIdRunPut({
       workflowId,
       v4WorkflowsWorkflowIdRunPutRequest: {
@@ -383,10 +341,7 @@ export class WorkflowsCoreService {
   /**
    * Get job status directly without polling workflow details
    */
-  async getJobStatus(
-    workflowId: WorkflowId,
-    jobId: JobId,
-  ): Promise<GetJobResponse> {
+  async getJobStatus(workflowId: WorkflowId, jobId: JobId): Promise<GetJobResponse> {
     const response = await this.workflowsApi.v4WorkflowsWorkflowIdJobsJobIdGet({
       workflowId,
       jobId,
@@ -397,11 +352,7 @@ export class WorkflowsCoreService {
   /**
    * Wait for a job to reach the target state or a terminal state
    */
-  async waitForJobCompletion(
-    workflowId: WorkflowId,
-    jobId: JobId,
-    options?: JobWaitOptions,
-  ): Promise<GetJobResponse> {
+  async waitForJobCompletion(workflowId: WorkflowId, jobId: JobId, options?: JobWaitOptions): Promise<GetJobResponse> {
     const result = await pollUntil(
       async () => {
         const current = await this.getJobStatus(workflowId, jobId);

--- a/sdks/node/test/unit/extraction-builder-service.test.ts
+++ b/sdks/node/test/unit/extraction-builder-service.test.ts
@@ -29,7 +29,6 @@ describe("ExtractionBuilderService", () => {
     expect(create).toHaveBeenCalledTimes(1);
     expect(create.mock.calls[0]?.[0]).toMatchObject({
       urls: ["https://example.com"],
-      navigationMode: "agentic-navigation",
       userPrompt:
         "extract all Product entities from this page and return these fields: title",
       entity: "Product",
@@ -58,7 +57,6 @@ describe("ExtractionBuilderService", () => {
       .create();
 
     expect(create.mock.calls[0]?.[0]).toMatchObject({
-      navigationMode: "agentic-navigation",
       userPrompt: "extract all the data for the main entity of this page",
       fields: [],
     });
@@ -90,7 +88,6 @@ describe("ExtractionBuilderService", () => {
       .create();
 
     expect(create.mock.calls[0]?.[0]).toMatchObject({
-      navigationMode: "agentic-navigation",
       userPrompt: "extract featured products only",
     });
   });
@@ -117,7 +114,6 @@ describe("ExtractionBuilderService", () => {
       .create();
 
     expect(create.mock.calls[0]?.[0]).toMatchObject({
-      navigationMode: "agentic-navigation",
       userPrompt:
         "extract all records from this page and return these fields: rawMarkdown",
     });
@@ -145,7 +141,6 @@ describe("ExtractionBuilderService", () => {
       .create();
 
     expect(create.mock.calls[0]?.[0]).toMatchObject({
-      navigationMode: "agentic-navigation",
       fields: [
         {
           name: "rawMarkdown",

--- a/sdks/node/test/unit/extraction-service.test.ts
+++ b/sdks/node/test/unit/extraction-service.test.ts
@@ -48,7 +48,6 @@ describe("ExtractionService", () => {
     expect(create).toHaveBeenCalledTimes(1);
     expect(create.mock.calls[0]?.[0]).toMatchObject({
       urls: ["https://example.com"],
-      navigationMode: "agentic-navigation",
       userPrompt: "extract all the data for the main entity of this page",
       fields: [],
       autoStart: true,
@@ -107,7 +106,6 @@ describe("ExtractionService", () => {
     });
 
     expect(create.mock.calls[0]?.[0]).toMatchObject({
-      navigationMode: "agentic-navigation",
       userPrompt:
         "extract all Product entities from this page and return these fields: title, price",
     });
@@ -175,7 +173,6 @@ describe("ExtractionService", () => {
 
     expect(result).toEqual({ workflowId: "wf-submit" });
     expect(create.mock.calls[0]?.[0]).toMatchObject({
-      navigationMode: "agentic-navigation",
       userPrompt: "extract all the data for the main entity of this page",
     });
   });

--- a/sdks/python/kadoa_sdk/extraction/services/entity_detector_service.py
+++ b/sdks/python/kadoa_sdk/extraction/services/entity_detector_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ...core.exceptions import KadoaErrorCode, KadoaHttpError, KadoaSdkError
 
@@ -16,7 +16,7 @@ class EntityDetectorService:
         self.client = client
 
     def fetch_entity_fields(
-        self, *, link: str, location: Union[Dict[str, Any], "LocationConfig"], navigation_mode: str
+        self, *, link: str, location: Union[Dict[str, Any], "LocationConfig"]
     ) -> Dict[str, Any]:
         if not link:
             raise KadoaSdkError(
@@ -36,15 +36,15 @@ class EntityDetectorService:
         else:
             location_dict = {"type": "auto"}
 
-        body = {"link": link, "location": location_dict, "navigationMode": navigation_mode}
+        body = {"link": link, "location": location_dict}
 
         try:
             data = self.client.make_raw_request(
-                    "POST",
+                "POST",
                 ENTITY_API_ENDPOINT,
-                    body=body,
+                body=body,
                 error_message=KadoaSdkError.ERROR_MESSAGES["ENTITY_FETCH_FAILED"],
-                )
+            )
 
             if not data.get("success") or not data.get("entityPrediction"):
                 raise KadoaSdkError(

--- a/sdks/python/kadoa_sdk/extraction/services/entity_resolver_service.py
+++ b/sdks/python/kadoa_sdk/extraction/services/entity_resolver_service.py
@@ -18,7 +18,6 @@ class EntityDetectionRequest(TypedDict, total=False):
     link: str
     selectorMode: bool
     location: Optional[LocationConfig]
-    navigationMode: Optional[str]
 
 
 class EntityPrediction(TypedDict, total=False):
@@ -52,7 +51,7 @@ class EntityResolverService:
         Args:
             entity_config: The entity configuration to resolve
             options: Additional options for AI detection
-                (link, location, navigationMode, selectorMode)
+                (link, location, selectorMode)
 
         Returns:
             ResolvedEntity with entity and fields
@@ -69,7 +68,6 @@ class EntityResolverService:
             entity_prediction = self.fetch_entity_fields(
                 link=options["link"],
                 location=options.get("location"),
-                navigation_mode=options.get("navigationMode"),
                 selector_mode=options.get("selectorMode", False),
             )
 
@@ -83,16 +81,24 @@ class EntityResolverService:
                 schema = self.client.schema.get_schema(entity_config["schemaId"])
                 # Convert schema fields to list of dicts
                 fields_list = []
-                schema_fields = getattr(schema, "var_schema", None) or getattr(schema, "schema", None) or []
+                schema_fields = (
+                    getattr(schema, "var_schema", None) or getattr(schema, "schema", None) or []
+                )
                 for field in schema_fields:
                     # Handle union types (SchemaResponseSchemaInner) - extract actual_instance
                     actual_field = getattr(field, "actual_instance", None) or field
                     if hasattr(actual_field, "model_dump"):
-                        fields_list.append(actual_field.model_dump(by_alias=True, exclude_none=True))
+                        fields_list.append(
+                            actual_field.model_dump(by_alias=True, exclude_none=True)
+                        )
                     elif isinstance(actual_field, dict):
                         fields_list.append(actual_field)
                     else:
-                        fields_list.append(dict(actual_field) if hasattr(actual_field, "__dict__") else actual_field)
+                        fields_list.append(
+                            dict(actual_field)
+                            if hasattr(actual_field, "__dict__")
+                            else actual_field
+                        )
                 return ResolvedEntity(
                     entity=getattr(schema, "entity", None),
                     fields=fields_list,
@@ -127,7 +133,6 @@ class EntityResolverService:
         *,
         link: str,
         location: Optional[LocationConfig] = None,
-        navigation_mode: Optional[str] = None,
         selector_mode: bool = False,
     ) -> EntityPrediction:
         """
@@ -136,7 +141,6 @@ class EntityResolverService:
         Args:
             link: URL to analyze
             location: Location configuration
-            navigation_mode: Navigation mode
             selector_mode: Whether to use selector mode
 
         Returns:
@@ -158,16 +162,14 @@ class EntityResolverService:
                 body["location"] = location
             else:
                 body["location"] = {"type": "auto"}
-        if navigation_mode is not None:
-            body["navigationMode"] = navigation_mode
 
         try:
             data = self.client.make_raw_request(
-                    "POST",
+                "POST",
                 ENTITY_API_ENDPOINT,
-                    body=body,
+                body=body,
                 error_message=KadoaSdkError.ERROR_MESSAGES["ENTITY_FETCH_FAILED"],
-                )
+            )
 
             if (
                 not data.get("success")

--- a/sdks/python/kadoa_sdk/extraction/types.py
+++ b/sdks/python/kadoa_sdk/extraction/types.py
@@ -169,7 +169,6 @@ class WaitForReadyOptions(BaseModel):
 DEFAULTS = {
     "polling_interval": 5.0,  # seconds
     "max_wait_time": 300.0,  # seconds
-    "navigation_mode": "agentic-navigation",
     "location": {"type": "auto"},
     "limit": 1000,
     "user_prompt": "extract all the data for the main entity of this page",

--- a/sdks/python/kadoa_sdk/workflows/workflows_core_service.py
+++ b/sdks/python/kadoa_sdk/workflows/workflows_core_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -17,9 +17,13 @@ if TYPE_CHECKING:  # pragma: no cover
 from kadoa_sdk.core.exceptions import KadoaErrorCode, KadoaHttpError, KadoaSdkError
 from kadoa_sdk.core.http import get_workflows_api
 from kadoa_sdk.extraction.types import RunWorkflowOptions
+from openapi_client.models.location import Location
+from openapi_client.models.monitoring_config import MonitoringConfig
+from openapi_client.models.prompt_workflow import PromptWorkflow as AgenticWorkflow
 from openapi_client.models.v4_workflows_workflow_id_run_put_request import (
     V4WorkflowsWorkflowIdRunPutRequest,
 )
+from openapi_client.models.workflow_with_existing_schema import WorkflowWithExistingSchema
 
 from ..extraction.extraction_acl import (
     CreateWorkflowBody,
@@ -33,18 +37,12 @@ from ..extraction.extraction_acl import (
     WorkflowsApi,
     WorkflowWithEntityAndFields,
 )
-from openapi_client.models.prompt_workflow import PromptWorkflow as AgenticWorkflow
-from openapi_client.models.create_workflow_response import CreateWorkflowResponse
-from openapi_client.models.workflow_with_existing_schema import WorkflowWithExistingSchema
-from openapi_client.models.location import Location
-from openapi_client.models.monitoring_config import MonitoringConfig
 
 
 class CreateWorkflowInput(BaseModel):
     """Input for creating a workflow."""
 
     urls: List[str]
-    navigation_mode: str = Field(alias="navigationMode")
     name: Optional[str] = None
     description: Optional[str] = None
     schema_id: Optional[str] = Field(default=None, alias="schemaId")
@@ -131,7 +129,7 @@ class WorkflowsCoreService:
         Create a new workflow.
 
         Args:
-            input: Workflow creation input with urls, navigationMode, fields, etc.
+            input: Workflow creation input with urls, userPrompt, fields, etc.
 
         Returns:
             CreateWorkflowResult with workflow id
@@ -145,24 +143,19 @@ class WorkflowsCoreService:
         domain_name = urlparse(input.urls[0]).hostname
 
         try:
-            if input.navigation_mode == "agentic-navigation":
-                if not input.user_prompt:
-                    raise KadoaSdkError(
-                        "userPrompt is required when navigationMode is 'agentic-navigation'",
-                        code=KadoaErrorCode.VALIDATION_ERROR,
-                        details={"navigationMode": input.navigation_mode},
-                    )
-
+            # Prompt-driven (agentic) workflows are routed by the presence of user_prompt.
+            if input.user_prompt:
                 agentic_request = AgenticWorkflow(
                     urls=input.urls,
-                    navigation_mode="agentic-navigation",
                     name=input.name or domain_name,
                     description=input.description,
                     user_prompt=input.user_prompt,
                     schema_id=input.schema_id,
                     entity=input.entity,
                     fields=input.fields,
-                    bypass_preview=input.bypass_preview if input.bypass_preview is not None else True,
+                    bypass_preview=input.bypass_preview
+                    if input.bypass_preview is not None
+                    else True,
                     tags=input.tags,
                     interval=input.interval,
                     monitoring=input.monitoring,
@@ -177,11 +170,12 @@ class WorkflowsCoreService:
                 # Use existing schema
                 schema_request = WorkflowWithExistingSchema(
                     urls=input.urls,
-                    navigation_mode=input.navigation_mode,
                     name=input.name or domain_name,
                     description=input.description,
                     schema_id=input.schema_id,
-                    bypass_preview=input.bypass_preview if input.bypass_preview is not None else True,
+                    bypass_preview=input.bypass_preview
+                    if input.bypass_preview is not None
+                    else True,
                     tags=input.tags,
                     interval=input.interval,
                     monitoring=input.monitoring,
@@ -196,12 +190,13 @@ class WorkflowsCoreService:
                 # Use entity and fields
                 workflow_request = WorkflowWithEntityAndFields(
                     urls=input.urls,
-                    navigation_mode=input.navigation_mode,
                     name=input.name or domain_name,
                     description=input.description,
                     entity=input.entity,
                     fields=input.fields,
-                    bypass_preview=input.bypass_preview if input.bypass_preview is not None else True,
+                    bypass_preview=input.bypass_preview
+                    if input.bypass_preview is not None
+                    else True,
                     tags=input.tags,
                     interval=input.interval,
                     monitoring=input.monitoring,
@@ -223,7 +218,9 @@ class WorkflowsCoreService:
                     KadoaSdkError.ERROR_MESSAGES["NO_WORKFLOW_ID"],
                     code=KadoaErrorCode.INTERNAL_ERROR,
                     details={
-                        "response": response.model_dump() if hasattr(response, "model_dump") else response
+                        "response": response.model_dump()
+                        if hasattr(response, "model_dump")
+                        else response
                     },
                 )
 
@@ -290,6 +287,7 @@ class WorkflowsCoreService:
                 return []
             # Convert to WorkflowResponse with enum remapping
             from ..extraction.extraction_acl import WorkflowResponse
+
             return [WorkflowResponse.from_generated(wf) for wf in workflows]
         except Exception as error:
             raise KadoaHttpError.wrap(


### PR DESCRIPTION
## What
The public Kadoa API removed the `navigationMode` parameter (KAD-7300). Prompt-driven workflows are now routed by the presence of `userPrompt`; the API ignores `agentic-navigation` and returns 400 for legacy modes (`single-page`, `paginated-page`, `page-and-detail`, `all-pages`). This drops `navigationMode` from the SDK.

## Changes
- **node**: removed the deprecated `navigationMode` input + the `NavigationMode` type, the conflicting-field check, and the `navigationMode: "agentic-navigation"` injection in the workflows + extraction services. Routing now relies on `userPrompt` (already sent). Unit tests updated.
- **python**: removed `navigation_mode` from `CreateWorkflowInput`, routed the agentic branch by `user_prompt`, and stopped sending `navigationMode` from the entity detector/resolver services.

## Validation
- node: `bun run build` and `bun test test/unit` pass (106 pass, 0 fail). The e2e/docs-snippet tests require a live API and were not run locally.
- python: `py_compile` passes on the edited files. Python tests were NOT run locally; please verify in CI.

## Scope note (draft)
Intentionally leaves `specs/openapi.json` unchanged. A full spec resync surfaces unrelated pre-existing drift (e.g. renamed template response types like `TemplateVersionCreatedResponseData`) that is out of scope for KAD-7300 and should be a separate regen/release. The generated client therefore still contains the now-unused navigationMode enum; this PR only removes the SDK's use of it. Draft pending full CI (esp. python).