### PR TITLE
feat(node-sdk): expose scrape API and team capabilities

### DIFF
--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -31,6 +31,25 @@ console.log(`Extracted ${result.data?.length} items`);
 // Output: Extracted 25 items
 ```
 
+## One-off page scraping
+
+Workspaces with the Scrape API capability can fetch a single page as compact markdown or raw HTML without creating a workflow:
+
+```typescript
+const { features } = await client.user.getFeatures();
+
+if (features.scrape) {
+  const page = await client.scrape.fetch({
+    url: 'https://example.com',
+    format: 'markdown',
+  });
+
+  console.log(page.content);
+}
+```
+
+Smart fetch and proxy routing are used by default. If a failed response explicitly recommends the anti-bot tier, retry with `proxy: 'stealth'`. Use `format: 'html'` when raw source is required. For structured extraction, recurring runs, or monitoring, use a workflow instead.
+
 ## Extraction Methods
 
 ### Default Extraction

--- a/sdks/node/src/client/api-registry.ts
+++ b/sdks/node/src/client/api-registry.ts
@@ -4,8 +4,10 @@ import {
   type BaseAPI,
   Configuration,
   DataValidationApi,
+  MeApi,
   NotificationsApi,
   SchemasApi,
+  ScrapeApi,
   TemplatesApi,
   VariablesApi,
   WorkflowsApi,
@@ -46,6 +48,14 @@ export class ApiRegistry {
 
   get schemas(): SchemasApi {
     return this.get(SchemasApi);
+  }
+
+  get me(): MeApi {
+    return this.get(MeApi);
+  }
+
+  get scrape(): ScrapeApi {
+    return this.get(ScrapeApi);
   }
 
   get validation(): DataValidationApi {

--- a/sdks/node/src/client/apis.acl.ts
+++ b/sdks/node/src/client/apis.acl.ts
@@ -1,8 +1,10 @@
 export {
   Configuration,
   DataValidationApi,
+  MeApi,
   NotificationsApi,
   SchemasApi,
+  ScrapeApi,
   TemplatesApi,
   VariablesApi,
   WorkflowsApi,

--- a/sdks/node/src/client/kadoa-client.ts
+++ b/sdks/node/src/client/kadoa-client.ts
@@ -9,6 +9,7 @@ import type {
 } from "../domains/extraction/services/extraction-builder.service";
 import { Realtime, type RealtimeConfig } from "../domains/realtime";
 import type { SchemasService } from "../domains/schemas/schemas.service";
+import type { ScrapeService } from "../domains/scrape/scrape.service";
 import type { TemplatesService } from "../domains/templates/templates.service";
 import type { UserService } from "../domains/user/user.service";
 import type { ValidationDomain } from "../domains/validation/validation.facade";
@@ -65,6 +66,7 @@ export class KadoaClient {
   public readonly workflow: WorkflowsCoreService;
   public readonly notification: NotificationDomain;
   public readonly schema: SchemasService;
+  public readonly scrape: ScrapeService;
   public readonly user: UserService;
   public readonly template: TemplatesService;
   public readonly validation: ValidationDomain;
@@ -123,6 +125,7 @@ export class KadoaClient {
     this.extraction = domains.extraction;
     this.workflow = domains.workflow;
     this.schema = domains.schema;
+    this.scrape = domains.scrape;
     this.notification = domains.notification;
     this.template = domains.template;
     this.validation = domains.validation;

--- a/sdks/node/src/client/wiring.ts
+++ b/sdks/node/src/client/wiring.ts
@@ -16,6 +16,7 @@ import { NotificationSetupService } from "../domains/notifications";
 import { NotificationChannelsService } from "../domains/notifications/notification-channels.service";
 import { NotificationSettingsService } from "../domains/notifications/notification-settings.service";
 import { SchemasService } from "../domains/schemas/schemas.service";
+import { ScrapeService } from "../domains/scrape/scrape.service";
 import { TemplatesService } from "../domains/templates/templates.service";
 import { UserService } from "../domains/user/user.service";
 import {
@@ -82,6 +83,7 @@ export function createClientDomains(params: { client: KadoaClient }): {
   workflow: WorkflowsCoreService;
   notification: NotificationDomain;
   schema: SchemasService;
+  scrape: ScrapeService;
   user: UserService;
   template: TemplatesService;
   validation: ValidationDomain;
@@ -101,6 +103,7 @@ export function createClientDomains(params: { client: KadoaClient }): {
     client.apis.notifications,
   );
   const schemasService = new SchemasService(client);
+  const scrapeService = new ScrapeService(client);
   const templatesService = new TemplatesService(client);
   const workflowsCoreService = new WorkflowsCoreService(
     client.apis.workflows,
@@ -145,6 +148,7 @@ export function createClientDomains(params: { client: KadoaClient }): {
     workflow: workflowsCoreService,
     notification,
     schema: schemasService,
+    scrape: scrapeService,
     user: userService,
     template: templatesService,
     validation,

--- a/sdks/node/src/domains/scrape/index.ts
+++ b/sdks/node/src/domains/scrape/index.ts
@@ -1,0 +1,2 @@
+export type { ScrapeRequest, ScrapeResponse } from "./scrape.acl";
+export { ScrapeService } from "./scrape.service";

--- a/sdks/node/src/domains/scrape/scrape.acl.ts
+++ b/sdks/node/src/domains/scrape/scrape.acl.ts
@@ -1,0 +1,14 @@
+/**
+ * Public scrape domain ACL.
+ * Re-exports generated request/response types behind stable SDK names.
+ */
+
+import {
+  ScrapeApi,
+  type V4ScrapePost200Response,
+  type V4ScrapePostRequest,
+} from "../../generated";
+
+export { ScrapeApi };
+export type ScrapeRequest = V4ScrapePostRequest;
+export type ScrapeResponse = V4ScrapePost200Response;

--- a/sdks/node/src/domains/scrape/scrape.service.ts
+++ b/sdks/node/src/domains/scrape/scrape.service.ts
@@ -1,0 +1,14 @@
+import type { KadoaClient } from "../../kadoa-client";
+import type { ScrapeRequest, ScrapeResponse } from "./scrape.acl";
+
+/** Fetch one URL through Kadoa's smart scrape routing. */
+export class ScrapeService {
+  constructor(private readonly client: KadoaClient) {}
+
+  async fetch(request: ScrapeRequest): Promise<ScrapeResponse> {
+    const response = await this.client.apis.scrape.v4ScrapePost({
+      v4ScrapePostRequest: request,
+    });
+    return response.data;
+  }
+}

--- a/sdks/node/src/domains/templates/templates.acl.ts
+++ b/sdks/node/src/domains/templates/templates.acl.ts
@@ -21,7 +21,7 @@ import {
   type TemplateWorkflowsResponseDataInner as GeneratedTemplateLinkedWorkflow,
   type TemplateResponse as GeneratedTemplateListItem,
   type TemplateSchemasResponseDataInner as GeneratedTemplateSchema,
-  type TemplateVersionCreatedResponseData as GeneratedTemplateVersion,
+  type TemplateVersionMutationResponseData as GeneratedTemplateVersion,
   type UnlinkWorkflowsBody as GeneratedUnlinkWorkflowsBody,
   type UnlinkWorkflowsResponse as GeneratedUnlinkWorkflowsResult,
   type UpdateTemplateBody as GeneratedUpdateTemplateBody,

--- a/sdks/node/src/domains/user/index.ts
+++ b/sdks/node/src/domains/user/index.ts
@@ -4,5 +4,6 @@
  */
 
 // User types and service (owned by user.service.ts)
+export type { KadoaFeatures } from "./user.acl";
 export type { KadoaUser } from "./user.service";
 export { UserService } from "./user.service";

--- a/sdks/node/src/domains/user/user.acl.ts
+++ b/sdks/node/src/domains/user/user.acl.ts
@@ -1,0 +1,3 @@
+import type { V4MeFeaturesGet200Response } from "../../generated";
+
+export type KadoaFeatures = V4MeFeaturesGet200Response;

--- a/sdks/node/src/domains/user/user.service.ts
+++ b/sdks/node/src/domains/user/user.service.ts
@@ -1,5 +1,6 @@
 import type { KadoaClient } from "../../kadoa-client";
 import { KadoaSdkException } from "../../runtime/exceptions";
+import type { KadoaFeatures } from "./user.acl";
 
 export interface KadoaUser {
   userId: string;
@@ -10,10 +11,19 @@ export interface KadoaUser {
 export class UserService {
   constructor(private readonly client: KadoaClient) {}
 
-  /**
-   * Get current user details
-   * @returns User details
-   */
+  /** Get customer-facing capabilities enabled for the active team. */
+  async getFeatures(): Promise<KadoaFeatures> {
+    const response = await this.client.apis.me.v4MeFeaturesGet();
+    const features = response.data?.features;
+
+    if (!features || typeof features.scrape !== "boolean") {
+      throw new KadoaSdkException("Invalid capabilities data received");
+    }
+
+    return response.data;
+  }
+
+  /** Get current user details. */
   async getCurrentUser(): Promise<KadoaUser> {
     const response = await this.client.axiosInstance.get("/v5/user", {
       baseURL: this.client.baseUrl,

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -13,6 +13,7 @@ export * from "./domains/extraction";
 export * from "./domains/notifications";
 export * from "./domains/realtime";
 export * from "./domains/schemas";
+export * from "./domains/scrape";
 export * from "./domains/templates";
 export * from "./domains/user";
 export * from "./domains/validation";

--- a/sdks/node/test/unit/scrape.service.test.ts
+++ b/sdks/node/test/unit/scrape.service.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AxiosResponse, InternalAxiosRequestConfig } from "axios";
+import { KadoaClient } from "../../src/client/kadoa-client";
+
+mock.module("../../src/runtime/utils/version-check", () => ({
+  checkForUpdates: () => Promise.resolve(),
+}));
+
+const scrapeResponse = {
+  success: true,
+  contentType: "text/markdown",
+  content: "# Example",
+  statusCode: 200,
+  finalUrl: "https://example.com/",
+  execution: { totalDurationMs: 12, attempts: [] },
+};
+
+async function captureScrape(
+  client: KadoaClient,
+  request: Parameters<KadoaClient["scrape"]["fetch"]>[0],
+): Promise<{
+  config: InternalAxiosRequestConfig;
+  result: Awaited<ReturnType<KadoaClient["scrape"]["fetch"]>>;
+}> {
+  let captured: InternalAxiosRequestConfig | undefined;
+  client.axiosInstance.defaults.adapter = async (config) => {
+    captured = config;
+    return {
+      data: scrapeResponse,
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config,
+    } as AxiosResponse;
+  };
+
+  const result = await client.scrape.fetch(request);
+  if (!captured) throw new Error("no request captured");
+  return { config: captured, result };
+}
+
+describe("ScrapeService", () => {
+  test("posts a scrape request and returns the response", async () => {
+    const client = new KadoaClient({ bearerToken: "jwt-test" });
+    const { config, result } = await captureScrape(client, {
+      url: "https://example.com",
+    });
+
+    expect(config.method).toBe("post");
+    expect(config.url).toBe("https://api.kadoa.com/v4/scrape");
+    expect(JSON.parse(config.data)).toEqual({ url: "https://example.com" });
+    expect(config.headers["Authorization"]).toBe("Bearer jwt-test");
+    expect(config.headers["x-api-key"]).toBeUndefined();
+    expect(result).toEqual(scrapeResponse);
+  });
+
+  test("passes public routing and format options unchanged", async () => {
+    const client = new KadoaClient({ apiKey: "tk-test" });
+    const { config } = await captureScrape(client, {
+      url: "https://example.com",
+      format: "html",
+      fetchMode: "browser",
+      proxy: "stealth",
+    });
+
+    expect(JSON.parse(config.data)).toEqual({
+      url: "https://example.com",
+      format: "html",
+      fetchMode: "browser",
+      proxy: "stealth",
+    });
+    expect(config.headers["x-api-key"]).toBe("tk-test");
+    expect(config.headers["Authorization"]).toBeUndefined();
+  });
+});

--- a/sdks/node/test/unit/user.service.test.ts
+++ b/sdks/node/test/unit/user.service.test.ts
@@ -35,7 +35,7 @@ async function captureRequest(
   return captured;
 }
 
-describe("UserService.getCurrentUser auth headers", () => {
+describe("UserService", () => {
   test("bearer-only mode emits Authorization and no x-api-key", async () => {
     const client = new KadoaClient({ bearerToken: "jwt-test" });
     const req = await captureRequest(client, () =>
@@ -52,5 +52,38 @@ describe("UserService.getCurrentUser auth headers", () => {
     );
     expect(req.headers["x-api-key"]).toBe("tk-test");
     expect(req.headers["Authorization"]).toBeUndefined();
+  });
+
+  test("getFeatures requests team capabilities with bearer auth", async () => {
+    const client = new KadoaClient({ bearerToken: "jwt-test" });
+    const req = await captureRequest(client, () => client.user.getFeatures(), {
+      features: { scrape: true },
+    });
+
+    expect(req.method).toBe("get");
+    expect(req.url).toBe("https://api.kadoa.com/v4/me/features");
+    expect(req.headers["Authorization"]).toBe("Bearer jwt-test");
+    expect(req.headers["x-api-key"]).toBeUndefined();
+  });
+
+  test("getFeatures returns the typed capability response", async () => {
+    const client = new KadoaClient({ apiKey: "tk-test" });
+    let result: unknown;
+    await captureRequest(
+      client,
+      async () => {
+        result = await client.user.getFeatures();
+      },
+      { features: { scrape: false } },
+    );
+
+    expect(result).toEqual({ features: { scrape: false } });
+  });
+
+  test("getFeatures rejects malformed capability responses", async () => {
+    const client = new KadoaClient({ apiKey: "tk-test" });
+    expect(
+      captureRequest(client, () => client.user.getFeatures(), { features: {} }),
+    ).rejects.toThrow("Invalid capabilities data received");
   });
 });

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -16788,6 +16788,1058 @@
           }
         ]
       }
+    },
+    "/v4/scrape": {
+      "post": {
+        "description": "Fetch a URL through Kadoa. Defaults to smart routing (auto fetch mode and proxy), can return page content as markdown for LLM consumption, and offers a stealth proxy tier for sites that block bots.",
+        "summary": "Scrape a URL",
+        "tags": [
+          "Scrape"
+        ],
+        "parameters": [],
+        "requestBody": {
+          "description": "Body",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "method": {
+                    "default": "GET",
+                    "type": "string",
+                    "enum": [
+                      "GET",
+                      "POST",
+                      "PUT",
+                      "DELETE",
+                      "PATCH"
+                    ],
+                    "description": "HTTP method. Default: GET"
+                  },
+                  "headers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "Header name"
+                        },
+                        "value": {
+                          "type": "string",
+                          "description": "Header value"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "value"
+                      ],
+                      "description": "Custom HTTP header"
+                    },
+                    "description": "Custom HTTP headers to send with the request"
+                  },
+                  "body": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "additionalProperties": {
+                          "nullable": true
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "Request body as JSON object, or a legacy worker-specific string. Prefer rawBody when the upstream endpoint needs an exact text payload."
+                  },
+                  "rawBody": {
+                    "type": "string",
+                    "description": "Exact request body text to forward to the upstream URL. Use for endpoints that reject wrapper objects or require a specific JSON/form payload string."
+                  },
+                  "location": {
+                    "type": "object",
+                    "properties": {
+                      "country": {
+                        "type": "string",
+                        "minLength": 2,
+                        "maxLength": 2,
+                        "description": "ISO 3166-1 alpha-2 country code (e.g., 'US', 'GB', 'DE')"
+                      }
+                    },
+                    "description": "Geo-targeting for proxy selection"
+                  },
+                  "timeout": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 60000,
+                    "description": "Per-attempt timeout in milliseconds"
+                  },
+                  "context": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "Context ID for session persistence. Use workflow ID for convenience. Created automatically if it does not exist."
+                      },
+                      "persist": {
+                        "type": "boolean",
+                        "description": "Save browser state (cookies, localStorage) after scrape. Default: false"
+                      }
+                    },
+                    "description": "Session context for cookie persistence"
+                  },
+                  "captureResponses": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "maxItems": 20,
+                    "description": "Substrings matched against network response URLs (browser workers only). The worker hooks every response the page makes and returns the body of each whose URL contains any of these substrings, in `capturedResponses`. Use this to read data that arrives via XHR/fetch and is NOT in the DOM — SPA dashboards (Tableau VizQL, Power BI) where values come back in a JSON/command response. Triggers a browser worker; pair with `browserActions` (clicks/waits) to drive the requests you want captured."
+                  },
+                  "waitUntil": {
+                    "type": "string",
+                    "enum": [
+                      "load",
+                      "domcontentloaded",
+                      "networkidle",
+                      "commit"
+                    ],
+                    "description": "Browser-worker navigation gate. Default (omitted) is `domcontentloaded` + a bounded best-effort networkidle settle, which returns content even on heavy pages that never go fully idle (ASP.NET, SignalR, ad/telemetry-heavy). Set `networkidle` to block the whole navigation on full idle (old behavior — only when the page reliably goes idle and you need every lazy request). No-op for non-browser workers."
+                  },
+                  "settleMs": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Browser-worker cap (ms) for the best-effort networkidle settle after `domcontentloaded`. Default 15000. Raise for slow client-rendered pages that need more time for lazy content; lower to return faster. Ignored when `waitUntil: networkidle` and for non-browser workers."
+                  },
+                  "device": {
+                    "type": "string",
+                    "description": "Device to emulate, by descriptor name (e.g. 'iPad', 'iPhone 13'). Honored by workers that support device emulation; ignored by the rest. Some sites only serve content for a given device profile."
+                  },
+                  "fetchMode": {
+                    "default": "auto",
+                    "type": "string",
+                    "enum": [
+                      "http",
+                      "browser",
+                      "auto"
+                    ],
+                    "description": "Fetch mode: http for fast requests, browser for JavaScript rendering and browser actions, or auto for smart routing that starts cheap and escalates when blocked. Default: auto"
+                  },
+                  "proxy": {
+                    "default": "auto",
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "dc",
+                      "isp",
+                      "residential",
+                      "stealth"
+                    ],
+                    "description": "Proxy tier: auto (smart selection), dc (datacenter), isp, residential, or stealth to route through the anti-bot providers for sites that block bots. Stealth providers use their own egress and pricing. Default: auto"
+                  },
+                  "format": {
+                    "default": "html",
+                    "type": "string",
+                    "enum": [
+                      "html",
+                      "markdown"
+                    ],
+                    "description": "Content format for HTML pages. markdown converts the page to markdown with navigation, header, and footer stripped — the compact shape to feed an LLM. Non-HTML responses (JSON, binary) and HTML pages over 2 MB are returned unchanged; check the response contentType to see which format was applied. Default: html"
+                  },
+                  "browserActions": {
+                    "type": "array",
+                    "items": {
+                      "discriminator": {
+                        "propertyName": "type"
+                      },
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "click"
+                              ],
+                              "description": "Action type"
+                            },
+                            "selector": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "xpath",
+                                    "css",
+                                    "text"
+                                  ],
+                                  "description": "Selector type"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "Selector value (e.g., '#submit-btn' for CSS, '//button[@type=\"submit\"]' for XPath)"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "value"
+                              ],
+                              "description": "Element to click"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "selector"
+                          ],
+                          "title": "click",
+                          "description": "Click an element on the page"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "input"
+                              ],
+                              "description": "Action type"
+                            },
+                            "selector": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "xpath",
+                                    "css",
+                                    "text"
+                                  ],
+                                  "description": "Selector type"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "Selector value (e.g., '#submit-btn' for CSS, '//button[@type=\"submit\"]' for XPath)"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "value"
+                              ],
+                              "description": "Input element to type into"
+                            },
+                            "value": {
+                              "type": "string",
+                              "description": "Text to type into the element"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "selector",
+                            "value"
+                          ],
+                          "title": "input",
+                          "description": "Type text into an input element"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "scroll"
+                              ],
+                              "description": "Action type"
+                            },
+                            "x": {
+                              "type": "number",
+                              "description": "Horizontal scroll amount in pixels"
+                            },
+                            "y": {
+                              "type": "number",
+                              "description": "Vertical scroll amount in pixels"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "y"
+                          ],
+                          "title": "scroll",
+                          "description": "Scroll by a specific number of pixels"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "scroll_to_bottom"
+                              ],
+                              "description": "Action type"
+                            },
+                            "timeout_s": {
+                              "type": "number",
+                              "description": "Maximum time to scroll in seconds (default: 30)"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "title": "scroll_to_bottom",
+                          "description": "Scroll to the bottom of the page (useful for infinite scroll)"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "wait"
+                              ],
+                              "description": "Action type"
+                            },
+                            "wait_time_s": {
+                              "type": "number",
+                              "description": "Duration to wait in seconds"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "wait_time_s"
+                          ],
+                          "title": "wait",
+                          "description": "Wait for a specified duration"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "screenshot"
+                              ],
+                              "description": "Action type"
+                            },
+                            "full_page": {
+                              "type": "boolean",
+                              "description": "Capture the full page (true) or just the viewport (false)"
+                            },
+                            "format": {
+                              "default": "jpg",
+                              "type": "string",
+                              "enum": [
+                                "jpg",
+                                "png",
+                                "webp"
+                              ],
+                              "description": "Output image format. Default: jpg"
+                            },
+                            "quality": {
+                              "default": 20,
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 100,
+                              "description": "Compression quality (1-100). Only applies to jpg and webp. Ignored for png. Default: 20"
+                            },
+                            "width": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "description": "Resize to this width in pixels (height scales proportionally). No upscaling."
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "title": "screenshot",
+                          "description": "Capture a screenshot of the page"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "evaluate_js"
+                              ],
+                              "description": "Action type"
+                            },
+                            "script": {
+                              "type": "string",
+                              "description": "JavaScript code to execute in the page context"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "script"
+                          ],
+                          "title": "evaluate_js",
+                          "description": "Execute JavaScript in the browser context"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "wait_for_element"
+                              ],
+                              "description": "Action type"
+                            },
+                            "selector": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "xpath",
+                                    "css",
+                                    "text"
+                                  ],
+                                  "description": "Selector type"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "Selector value (e.g., '#submit-btn' for CSS, '//button[@type=\"submit\"]' for XPath)"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "value"
+                              ],
+                              "description": "Element to wait for"
+                            },
+                            "timeout_s": {
+                              "type": "number",
+                              "description": "Maximum time to wait in seconds (default: 10)"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "selector"
+                          ],
+                          "title": "wait_for_element",
+                          "description": "Wait for an element to appear on the page"
+                        }
+                      ],
+                      "description": "Browser action to perform on the page"
+                    },
+                    "maxItems": 50
+                  }
+                },
+                "required": [
+                  "url"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Scrape response with content and execution metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Whether the scrape succeeded"
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "description": "MIME type of the response (e.g., text/html, application/json, image/png)"
+                    },
+                    "content": {
+                      "type": "string",
+                      "description": "Response content (raw text for html/json, base64 for binary)"
+                    },
+                    "isBase64": {
+                      "default": false,
+                      "type": "boolean",
+                      "description": "Whether content is base64-encoded (true for binary content types like PDFs, images)"
+                    },
+                    "screenshots": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "URLs of captured screenshots"
+                    },
+                    "jsResults": {
+                      "type": "array",
+                      "items": {
+                        "nullable": true
+                      },
+                      "description": "Results of evaluate_js actions, in order of execution. Each entry is the JSON-serializable return value, or {error: string} if the script threw."
+                    },
+                    "capturedResponses": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string",
+                            "description": "Full URL of the captured response"
+                          },
+                          "status": {
+                            "type": "number",
+                            "description": "HTTP status code of the captured response"
+                          },
+                          "body": {
+                            "type": "string",
+                            "description": "Response body as text"
+                          }
+                        },
+                        "required": [
+                          "url",
+                          "status",
+                          "body"
+                        ]
+                      },
+                      "description": "Bodies of network responses whose URL matched a `captureResponses` substring, in arrival order. Present only when `captureResponses` was set and at least one response matched."
+                    },
+                    "statusCode": {
+                      "type": "number",
+                      "description": "HTTP status code from the response"
+                    },
+                    "headers": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Response headers as key-value pairs"
+                    },
+                    "cookies": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "Cookie name"
+                          },
+                          "value": {
+                            "type": "string",
+                            "description": "Cookie value"
+                          },
+                          "domain": {
+                            "type": "string",
+                            "description": "Cookie domain"
+                          },
+                          "path": {
+                            "type": "string",
+                            "description": "Cookie path"
+                          },
+                          "expires": {
+                            "type": "number",
+                            "description": "Expiration timestamp (Unix epoch)"
+                          },
+                          "httpOnly": {
+                            "type": "boolean",
+                            "description": "HttpOnly flag"
+                          },
+                          "secure": {
+                            "type": "boolean",
+                            "description": "Secure flag"
+                          },
+                          "sameSite": {
+                            "type": "string",
+                            "enum": [
+                              "Strict",
+                              "Lax",
+                              "None"
+                            ],
+                            "description": "SameSite attribute"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "description": "HTTP cookie from the response"
+                      },
+                      "description": "Cookies set by the response"
+                    },
+                    "finalUrl": {
+                      "type": "string",
+                      "description": "Final URL after any redirects"
+                    },
+                    "execution": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Opaque request identifier for correlating scraper API and worker lifecycle diagnostics"
+                        },
+                        "totalDurationMs": {
+                          "type": "number",
+                          "description": "Total time including all retries in milliseconds"
+                        },
+                        "contextId": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Context ID used or created, if context feature was used"
+                        },
+                        "contextPersisted": {
+                          "type": "boolean",
+                          "description": "Whether browser state was saved back to context"
+                        },
+                        "attempts": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "worker": {
+                                "type": "string",
+                                "enum": [
+                                  "http",
+                                  "browser",
+                                  "stealth-http",
+                                  "stealth-browser"
+                                ],
+                                "description": "Worker capability used for this attempt"
+                              },
+                              "proxy": {
+                                "type": "string",
+                                "enum": [
+                                  "dc",
+                                  "isp",
+                                  "residential"
+                                ],
+                                "description": "Proxy type: datacenter, ISP, or residential",
+                                "nullable": true
+                              },
+                              "location": {
+                                "type": "object",
+                                "properties": {
+                                  "country": {
+                                    "type": "string",
+                                    "minLength": 2,
+                                    "maxLength": 2,
+                                    "description": "ISO 3166-1 alpha-2 country code (e.g., 'US', 'GB', 'DE')"
+                                  }
+                                },
+                                "description": "Location used for geo-targeting, or null",
+                                "nullable": true
+                              },
+                              "startedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "ISO 8601 timestamp when attempt started"
+                              },
+                              "endedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "ISO 8601 timestamp when attempt ended"
+                              },
+                              "durationMs": {
+                                "type": "number",
+                                "description": "Attempt duration in milliseconds"
+                              },
+                              "success": {
+                                "type": "boolean",
+                                "description": "Whether this attempt succeeded"
+                              },
+                              "error": {
+                                "type": "object",
+                                "properties": {
+                                  "code": {
+                                    "type": "string",
+                                    "enum": [
+                                      "BOT_DETECTED",
+                                      "TIMEOUT",
+                                      "JS_REQUIRED",
+                                      "KYC_BLOCKED",
+                                      "MAX_RETRIES_EXCEEDED",
+                                      "NETWORK_ERROR"
+                                    ],
+                                    "description": "Error code"
+                                  },
+                                  "message": {
+                                    "type": "string",
+                                    "description": "Human-readable error message"
+                                  }
+                                },
+                                "required": [
+                                  "code",
+                                  "message"
+                                ],
+                                "description": "Error details if attempt failed"
+                              }
+                            },
+                            "required": [
+                              "worker",
+                              "proxy",
+                              "location",
+                              "startedAt",
+                              "endedAt",
+                              "durationMs",
+                              "success"
+                            ],
+                            "description": "Details of a single scrape attempt"
+                          }
+                        }
+                      },
+                      "required": [
+                        "totalDurationMs",
+                        "attempts"
+                      ],
+                      "description": "Execution metadata including timing and retry information"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "enum": [
+                            "BOT_DETECTED",
+                            "TIMEOUT",
+                            "JS_REQUIRED",
+                            "KYC_BLOCKED",
+                            "MAX_RETRIES_EXCEEDED",
+                            "NETWORK_ERROR"
+                          ],
+                          "description": "Error code"
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable error message"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "description": "Error details when success is false"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "execution"
+                  ],
+                  "description": "Scrape response with content and execution metadata"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "429",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "502",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "504",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v4/me/features": {
+      "get": {
+        "description": "Return the capabilities enabled for the authenticated team. Clients (such as the Kadoa MCP) use this to decide which tools to expose.",
+        "summary": "Get enabled capabilities",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "features": {
+                      "type": "object",
+                      "properties": {
+                        "scrape": {
+                          "type": "boolean",
+                          "description": "Whether this team may call POST /v4/scrape (the Scrape API)."
+                        }
+                      },
+                      "required": [
+                        "scrape"
+                      ],
+                      "description": "Capabilities enabled for the authenticated team."
+                    }
+                  },
+                  "required": [
+                    "features"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "description": "Indicates an error occurred"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    },
+                    "details": {
+                      "nullable": true,
+                      "description": "Additional error details (e.g., validation errors)"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "description": "Indicates an error occurred"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    },
+                    "details": {
+                      "nullable": true,
+                      "description": "Additional error details (e.g., validation errors)"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
     }
   },
   "components": {


### PR DESCRIPTION
## Summary
- refresh the OpenAPI spec with `/v4/scrape` and `/v4/me/features` from latest backend main
- add `client.scrape.fetch()` and `client.user.getFeatures()`
- add unit coverage and SDK documentation
- update the renamed template version response type required by regenerated clients

## Validation
- 111 Node SDK unit tests pass
- Node SDK typecheck passes
- Node SDK build passes

Implements the SDK portion of KAD-15475.