### PR TITLE
feat(node-sdk): type workflow management parity fields

### DIFF
--- a/sdks/node/src/client/api-registry.ts
+++ b/sdks/node/src/client/api-registry.ts
@@ -1,6 +1,7 @@
 import type { AxiosInstance } from "axios";
 import { CrawlerApi } from "../domains/crawler/crawler.acl";
 import {
+  AgentApi,
   type BaseAPI,
   Configuration,
   DataValidationApi,
@@ -44,6 +45,10 @@ export class ApiRegistry {
       );
     }
     return this.cache.get(ApiClass) as T;
+  }
+
+  get agent(): AgentApi {
+    return this.get(AgentApi);
   }
 
   get schemas(): SchemasApi {

--- a/sdks/node/src/client/apis.acl.ts
+++ b/sdks/node/src/client/apis.acl.ts
@@ -1,4 +1,5 @@
 export {
+  AgentApi,
   Configuration,
   DataValidationApi,
   MeApi,

--- a/sdks/node/src/client/kadoa-client.ts
+++ b/sdks/node/src/client/kadoa-client.ts
@@ -1,4 +1,5 @@
 import type { AxiosInstance } from "axios";
+import type { AssistantService } from "../domains/assistant";
 import type { ChangesService } from "../domains/changes/changes.service";
 import type { CrawlerDomain } from "../domains/crawler";
 import type { ExtractionService } from "../domains/extraction/services/extraction.service";
@@ -61,6 +62,7 @@ export class KadoaClient {
   private readonly _extractionBuilderService: ExtractionBuilderService;
 
   public readonly apis: ApiRegistry;
+  public readonly assistant: AssistantService;
   public readonly changes: ChangesService;
   public readonly extraction: ExtractionService;
   public readonly workflow: WorkflowsCoreService;
@@ -120,6 +122,7 @@ export class KadoaClient {
 
     const domains = createClientDomains({ client: this });
 
+    this.assistant = domains.assistant;
     this.changes = domains.changes;
     this.user = domains.user;
     this.extraction = domains.extraction;

--- a/sdks/node/src/client/wiring.ts
+++ b/sdks/node/src/client/wiring.ts
@@ -1,6 +1,7 @@
 import type { AxiosInstance } from "axios";
 import axios, { AxiosError } from "axios";
 import { v4 } from "uuid";
+import { AssistantService } from "../domains/assistant";
 import { ChangesService } from "../domains/changes/changes.service";
 import { type CrawlerDomain, createCrawlerDomain } from "../domains/crawler";
 import { DataFetcherService } from "../domains/extraction/services/data-fetcher.service";
@@ -77,6 +78,7 @@ export function createAxiosInstance(params: {
 }
 
 export function createClientDomains(params: { client: KadoaClient }): {
+  assistant: AssistantService;
   changes: ChangesService;
   extractionBuilderService: ExtractionBuilderService;
   extraction: ExtractionService;
@@ -92,6 +94,7 @@ export function createClientDomains(params: { client: KadoaClient }): {
 } {
   const { client } = params;
 
+  const assistantService = new AssistantService(client.apis.agent);
   const changesService = new ChangesService(client);
   const userService = new UserService(client);
   const dataFetcherService = new DataFetcherService(client.apis.workflows);
@@ -142,6 +145,7 @@ export function createClientDomains(params: { client: KadoaClient }): {
   const crawler = createCrawlerDomain(client);
 
   return {
+    assistant: assistantService,
     changes: changesService,
     extractionBuilderService,
     extraction: extractionService,

--- a/sdks/node/src/domains/assistant/assistant.acl.ts
+++ b/sdks/node/src/domains/assistant/assistant.acl.ts
@@ -1,0 +1,38 @@
+import type {
+  AgentApiInterface,
+  AssistantAnswerResponseData,
+  AssistantPauseStateResponseData,
+  AssistantPauseStateResponseDataPause,
+  AssistantPauseStateResponseDataPendingQuestion,
+  AssistantQuestion,
+  ExtractionStrategySummary,
+  WorkflowAssistantMessageResponseData,
+} from "../../generated";
+
+export type { AgentApiInterface };
+
+export const FREEFORM_ASSISTANT_ANSWER_KEY = "_freeform" as const;
+
+export interface WorkflowAssistantUpdateInput {
+  instructions: string;
+  threadId?: string;
+}
+
+export type WorkflowAssistantUpdateAccepted =
+  WorkflowAssistantMessageResponseData;
+export type AssistantPauseState = AssistantPauseStateResponseData;
+export type AssistantPause = AssistantPauseStateResponseDataPause;
+export type AssistantPendingQuestion =
+  AssistantPauseStateResponseDataPendingQuestion;
+export type { AssistantQuestion };
+export type AssistantQuestionAnswers = Record<string, string>;
+
+export interface AssistantQuestionAnswerInput {
+  sessionId: string;
+  questionId: string;
+  threadId?: string;
+  answers: AssistantQuestionAnswers;
+}
+
+export type AssistantQuestionAnswerResult = AssistantAnswerResponseData;
+export type AssistantExtractionStrategy = ExtractionStrategySummary;

--- a/sdks/node/src/domains/assistant/assistant.service.ts
+++ b/sdks/node/src/domains/assistant/assistant.service.ts
@@ -1,0 +1,66 @@
+import { KadoaSdkException } from "../../runtime/exceptions";
+import type {
+  AgentApiInterface,
+  AssistantExtractionStrategy,
+  AssistantPauseState,
+  AssistantQuestionAnswerInput,
+  AssistantQuestionAnswerResult,
+  WorkflowAssistantUpdateAccepted,
+  WorkflowAssistantUpdateInput,
+} from "./assistant.acl";
+
+export class AssistantService {
+  constructor(private readonly agentApi: AgentApiInterface) {}
+
+  async requestWorkflowUpdate(
+    workflowId: string,
+    input: WorkflowAssistantUpdateInput,
+  ): Promise<WorkflowAssistantUpdateAccepted> {
+    const response = await this.agentApi.v5AgentWorkflowAssistantMessage({
+      workflowId,
+      workflowAssistantMessageRequest: {
+        prompt: input.instructions,
+        ...(input.threadId != null && { threadId: input.threadId }),
+      },
+    });
+    const data = response.data?.data;
+
+    if (!data?.workflowId || !data.sessionId || !data.threadId) {
+      throw new KadoaSdkException(
+        "Workflow Assistant update response is missing required identifiers",
+        {
+          code: "INTERNAL_ERROR",
+          details: { workflowId, response: response.data },
+        },
+      );
+    }
+
+    return data;
+  }
+
+  async getPauseState(sessionId: string): Promise<AssistantPauseState> {
+    const response = await this.agentApi.v5AgentPauseState({ sessionId });
+    return response.data.data;
+  }
+
+  async answerQuestion(
+    input: AssistantQuestionAnswerInput,
+  ): Promise<AssistantQuestionAnswerResult> {
+    const response = await this.agentApi.v5AgentAnswer({
+      assistantAnswerRequest: {
+        sessionId: input.sessionId,
+        questionId: input.questionId,
+        answers: input.answers,
+        ...(input.threadId != null && { threadId: input.threadId }),
+      },
+    });
+    return response.data.data;
+  }
+
+  async getStrategy(
+    sessionId: string,
+  ): Promise<AssistantExtractionStrategy | null> {
+    const response = await this.agentApi.v5AgentStrategy({ sessionId });
+    return response.data.data.strategy;
+  }
+}

--- a/sdks/node/src/domains/assistant/index.ts
+++ b/sdks/node/src/domains/assistant/index.ts
@@ -1,0 +1,15 @@
+export {
+  type AgentApiInterface,
+  type AssistantExtractionStrategy,
+  type AssistantPause,
+  type AssistantPauseState,
+  type AssistantPendingQuestion,
+  type AssistantQuestion,
+  type AssistantQuestionAnswerInput,
+  type AssistantQuestionAnswerResult,
+  type AssistantQuestionAnswers,
+  FREEFORM_ASSISTANT_ANSWER_KEY,
+  type WorkflowAssistantUpdateAccepted,
+  type WorkflowAssistantUpdateInput,
+} from "./assistant.acl";
+export { AssistantService } from "./assistant.service";

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -7,6 +7,7 @@
 // ============================================================================
 // Domain Services & Types
 // ============================================================================
+export * from "./domains/assistant";
 export * from "./domains/changes";
 export * from "./domains/crawler";
 export * from "./domains/extraction";

--- a/sdks/node/test/unit/assistant.service.test.ts
+++ b/sdks/node/test/unit/assistant.service.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../src/runtime/utils/version-check", () => ({
+  checkForUpdates: () => Promise.resolve(),
+}));
+
+import { KadoaClient } from "../../src/client/kadoa-client";
+import { KadoaSdkException } from "../../src/runtime/exceptions";
+
+const mockUpdate = mock();
+const mockPauseState = mock();
+const mockAnswer = mock();
+const mockStrategy = mock();
+
+function createTestClient(): KadoaClient {
+  const client = new KadoaClient({ apiKey: "tk-test" });
+  const agent = (client.apis as any).agent;
+  agent.v5AgentWorkflowAssistantMessage = mockUpdate;
+  agent.v5AgentPauseState = mockPauseState;
+  agent.v5AgentAnswer = mockAnswer;
+  agent.v5AgentStrategy = mockStrategy;
+  return client;
+}
+
+const updateData = {
+  workflowId: "11111111-1111-4111-8111-111111111111",
+  sessionId: "22222222-2222-4222-8222-222222222222",
+  threadId: "33333333-3333-4333-8333-333333333333",
+  jobId: "job-1",
+  inputEventId: "event-1",
+  alreadyBootstrapped: true,
+};
+
+const pauseState = {
+  paused: true,
+  pause: {
+    id: "question-1",
+    reason: "question" as const,
+    status: "active" as const,
+    threadId: updateData.threadId,
+    pausedAt: "2026-07-28T10:00:00.000Z",
+  },
+  pendingQuestion: {
+    questionId: "question-1",
+    threadId: updateData.threadId,
+    questions: [
+      {
+        header: "Source",
+        question: "Which source should be used?",
+        answerType: "freeform" as const,
+        options: [],
+        metadata: { customerSafe: true },
+      },
+    ],
+    askedAt: "2026-07-28T10:00:00.000Z",
+  },
+};
+
+const strategy = {
+  approach: "direct-api",
+  summary: "Reads the public JSON API.",
+  dataSource: {
+    type: "api",
+    endpoints: ["/v1/items"],
+    interactionStyle: "request-response",
+    selectors: [],
+  },
+  intervalSeconds: null,
+};
+
+describe("AssistantService", () => {
+  beforeEach(() => {
+    mockUpdate.mockReset();
+    mockPauseState.mockReset();
+    mockAnswer.mockReset();
+    mockStrategy.mockReset();
+  });
+
+  test("requests an identity-preserving workflow update", async () => {
+    mockUpdate.mockResolvedValueOnce({
+      data: { data: updateData, status: "success", message: "Message sent" },
+    });
+    const client = createTestClient();
+
+    const result = await client.assistant.requestWorkflowUpdate(
+      updateData.workflowId,
+      {
+        instructions: "Add pagination",
+        threadId: updateData.threadId,
+      },
+    );
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      workflowId: updateData.workflowId,
+      workflowAssistantMessageRequest: {
+        prompt: "Add pagination",
+        threadId: updateData.threadId,
+      },
+    });
+    expect(result).toEqual(updateData);
+  });
+
+  test("preserves a nullable dispatch job id", async () => {
+    mockUpdate.mockResolvedValueOnce({
+      data: {
+        data: { ...updateData, jobId: null },
+        status: "success",
+        message: "Message sent",
+      },
+    });
+    const result = await createTestClient().assistant.requestWorkflowUpdate(
+      updateData.workflowId,
+      {
+        instructions: "Repair pagination",
+      },
+    );
+
+    expect(result.jobId).toBeNull();
+  });
+
+  test("rejects a malformed successful update response", async () => {
+    mockUpdate.mockResolvedValueOnce({
+      data: {
+        data: { ...updateData, workflowId: undefined },
+        status: "success",
+        message: "Message sent",
+      },
+    });
+
+    await expect(
+      createTestClient().assistant.requestWorkflowUpdate(
+        updateData.workflowId,
+        { instructions: "Add pagination" },
+      ),
+    ).rejects.toBeInstanceOf(KadoaSdkException);
+  });
+
+  test("returns durable pause state without dropping question metadata", async () => {
+    mockPauseState.mockResolvedValueOnce({
+      data: { data: pauseState, status: "success" },
+    });
+
+    const result = await createTestClient().assistant.getPauseState(
+      updateData.sessionId,
+    );
+
+    expect(mockPauseState).toHaveBeenCalledWith({
+      sessionId: updateData.sessionId,
+    });
+    expect(result).toEqual(pauseState);
+    expect(result.pendingQuestion?.questions[0]?.metadata).toEqual({
+      customerSafe: true,
+    });
+  });
+
+  test("submits a structured question answer", async () => {
+    mockAnswer.mockResolvedValueOnce({
+      data: {
+        data: { success: true },
+        status: "success",
+        message: "Answer submitted successfully",
+      },
+    });
+    const client = createTestClient();
+
+    const result = await client.assistant.answerQuestion({
+      sessionId: updateData.sessionId,
+      questionId: "question-1",
+      threadId: updateData.threadId,
+      answers: { _freeform: "Use the API" },
+    });
+
+    expect(mockAnswer).toHaveBeenCalledWith({
+      assistantAnswerRequest: {
+        sessionId: updateData.sessionId,
+        questionId: "question-1",
+        threadId: updateData.threadId,
+        answers: { _freeform: "Use the API" },
+      },
+    });
+    expect(result).toEqual({ success: true });
+  });
+
+  test("returns the current extraction strategy", async () => {
+    mockStrategy.mockResolvedValueOnce({
+      data: { data: { strategy }, status: "success" },
+    });
+
+    const result = await createTestClient().assistant.getStrategy(
+      updateData.sessionId,
+    );
+
+    expect(mockStrategy).toHaveBeenCalledWith({
+      sessionId: updateData.sessionId,
+    });
+    expect(result).toEqual(strategy);
+  });
+
+  test("returns null when no build strategy exists", async () => {
+    mockStrategy.mockResolvedValueOnce({
+      data: { data: { strategy: null }, status: "success" },
+    });
+
+    expect(
+      await createTestClient().assistant.getStrategy(updateData.sessionId),
+    ).toBeNull();
+  });
+
+  test("propagates generated API errors", async () => {
+    mockPauseState.mockRejectedValueOnce(new Error("manager unavailable"));
+
+    await expect(
+      createTestClient().assistant.getPauseState(updateData.sessionId),
+    ).rejects.toThrow("manager unavailable");
+  });
+});

--- a/sdks/node/test/unit/workflows-management-parity.test.ts
+++ b/sdks/node/test/unit/workflows-management-parity.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../src/runtime/utils/version-check", () => ({
+  checkForUpdates: () => Promise.resolve(),
+}));
+
+import { KadoaClient } from "../../src/client/kadoa-client";
+import type {
+  GetWorkflowResponse,
+  UpdateWorkflowRequest,
+} from "../../src/domains/workflows/workflows.acl";
+
+const mockUpdate = mock();
+const mockGet = mock();
+
+function createTestClient(): KadoaClient {
+  const client = new KadoaClient({ apiKey: "tk-test" });
+  Object.assign(client.apis.workflows, {
+    v4WorkflowsWorkflowIdMetadataPut: mockUpdate,
+    v4WorkflowsWorkflowIdGet: mockGet,
+  });
+  return client;
+}
+
+describe("workflow management parity", () => {
+  beforeEach(() => {
+    mockUpdate.mockReset();
+    mockGet.mockReset();
+  });
+
+  test("forwards deterministic settings without dropping nullable unlimited rows", async () => {
+    mockUpdate.mockResolvedValueOnce({ data: { success: true } });
+    const input = {
+      limit: null,
+      timezone: "America/New_York",
+      location: { type: "manual", isoCode: "US" },
+      monitoring: {
+        fields: [
+          { fieldName: "price", operator: "changed", isKeyField: false },
+        ],
+        conditions: {
+          logicalOperator: "AND",
+          conditions: [
+            {
+              type: "SINGLE",
+              field: "price",
+              operator: "GREATER_THAN",
+              value: 100,
+            },
+          ],
+        },
+      },
+    } satisfies UpdateWorkflowRequest;
+
+    const client = createTestClient();
+    await client.workflow.update("wf-1", input);
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      workflowId: "wf-1",
+      v4WorkflowsWorkflowIdMetadataPutRequest: input,
+    });
+  });
+
+  test("types and returns the canonical workflow management detail fields", async () => {
+    const response = {
+      id: "wf-1",
+      entity: "Product",
+      extractionSpec: { rawPrompt: "Extract every product" },
+      dataStale: true,
+      scheduleTimezone: "America/New_York",
+      assistantEligible: true,
+      assistantSessionId: "session-1",
+      assistantThreadId: "thread-1",
+      sessionStatus: "idle",
+      templateId: "template-1",
+      templateVersion: 3,
+      templateHasPrompt: true,
+      templateHasSchema: true,
+      templateHasNotifications: false,
+      templateHasFrequency: true,
+      observerHealth: { healthTier: "HEALTHY" },
+      channelCounts: { EMAIL: 1 },
+    } satisfies GetWorkflowResponse;
+    mockGet.mockResolvedValueOnce({ data: response });
+
+    const client = createTestClient();
+    const workflow = await client.workflow.get("wf-1");
+
+    expect(workflow).toEqual(response);
+    expect(workflow.extractionSpec).toEqual({
+      rawPrompt: "Extract every product",
+    });
+    expect(workflow.templateHasFrequency).toBe(true);
+    expect(workflow.scheduleTimezone).toBe("America/New_York");
+  });
+});

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -1864,12 +1864,23 @@
                       "type": "boolean",
                       "description": "Whether this workflow should be displayed as realtime"
                     },
+                    "lastDataChangedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true,
+                      "description": "Most recent persisted customer-visible data change for a real-time workflow"
+                    },
                     "schedules": {
                       "type": "array",
                       "items": {
                         "type": "string"
                       },
                       "description": "Cron schedules for updates"
+                    },
+                    "scheduleTimezone": {
+                      "type": "string",
+                      "example": "America/New_York",
+                      "description": "IANA timezone used to evaluate cron schedules"
                     },
                     "nextInvocation": {
                       "type": "string",
@@ -1892,13 +1903,7 @@
                         },
                         "isoCode": {
                           "type": "string",
-                          "enum": [
-                            "DE",
-                            "US",
-                            "GB",
-                            "NL",
-                            "CA"
-                          ]
+                          "description": "Supported country ISO code when type is manual"
                         }
                       },
                       "description": "Scraping location configuration"
@@ -1918,9 +1923,63 @@
                       "type": "string",
                       "description": "ID of the schema used"
                     },
+                    "templateName": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Name of the linked workflow template"
+                    },
+                    "templateId": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "ID of the linked workflow template"
+                    },
+                    "templateVersion": {
+                      "type": "integer",
+                      "nullable": true,
+                      "description": "Applied template version"
+                    },
+                    "templateHasPrompt": {
+                      "type": "boolean",
+                      "description": "Whether the template controls the workflow prompt"
+                    },
+                    "templateHasSchema": {
+                      "type": "boolean",
+                      "description": "Whether the template controls the extraction schema"
+                    },
+                    "templateHasSchemaValidationRules": {
+                      "type": "boolean",
+                      "description": "Whether the template controls schema validation rules"
+                    },
+                    "templateHasNotifications": {
+                      "type": "boolean",
+                      "description": "Whether the template controls notification settings"
+                    },
+                    "templateHasFrequency": {
+                      "type": "boolean",
+                      "description": "Whether the template controls schedule/frequency"
+                    },
+                    "hasSchemaValidationRules": {
+                      "type": "boolean",
+                      "description": "Whether this workflow has schema validation rules"
+                    },
+                    "channelCounts": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "integer"
+                      },
+                      "description": "Notification channel counts grouped by channel type"
+                    },
                     "jobId": {
                       "type": "string",
                       "description": "ID of the last job"
+                    },
+                    "isFirstRun": {
+                      "type": "boolean",
+                      "description": "Whether the workflow has not completed a regular run yet"
+                    },
+                    "dataQualityIssues": {
+                      "type": "integer",
+                      "description": "Number of data-quality issues in the latest finished run"
                     },
                     "finishedAt": {
                       "type": "string",
@@ -2029,28 +2088,17 @@
                         }
                       }
                     },
-                    "navigationMode": {
-                      "type": "string",
-                      "enum": [
-                        "single-page",
-                        "paginated-page",
-                        "page-and-detail",
-                        "agentic-navigation",
-                        "all-pages"
-                      ],
-                      "description": "Navigation mode for scraping. Determines how the scraper navigates through pages"
-                    },
                     "maxDepth": {
                       "type": "integer",
                       "minimum": 1,
                       "maximum": 200,
-                      "description": "Maximum crawl depth (default: 50, max: 200). Only used when navigationMode is 'all-pages'"
+                      "description": "Maximum crawl depth (default: 50, max: 200)."
                     },
                     "maxPages": {
                       "type": "integer",
                       "minimum": 1,
                       "maximum": 100000,
-                      "description": "Maximum pages to crawl (default: 10,000, max: 100,000). Only used when navigationMode is 'all-pages'"
+                      "description": "Maximum pages to crawl (default: 10,000, max: 100,000)."
                     },
                     "schema": {
                       "type": "array",
@@ -2096,8 +2144,17 @@
                       "description": "Extraction schema fields"
                     },
                     "entity": {
+                      "type": "string",
+                      "description": "Canonical extracted entity name"
+                    },
+                    "extractionSpec": {
                       "type": "object",
-                      "description": "Entity information"
+                      "additionalProperties": true,
+                      "description": "Canonical extraction intent for Assistant-built workflows"
+                    },
+                    "dataStale": {
+                      "type": "boolean",
+                      "description": "Whether batch workflow data predates the current canonical configuration/build"
                     },
                     "isSchemaEditable": {
                       "type": "boolean",
@@ -2155,14 +2212,16 @@
                     },
                     "notificationConfig": {
                       "type": "object",
+                      "nullable": true,
                       "properties": {
-                        "enabled": {
-                          "type": "boolean"
-                        },
-                        "fields": {
+                        "monitoredFields": {
                           "type": "array",
                           "items": {
                             "type": "object",
+                            "required": [
+                              "fieldName",
+                              "operator"
+                            ],
                             "properties": {
                               "fieldName": {
                                 "type": "string"
@@ -2174,12 +2233,20 @@
                                   "added",
                                   "removed"
                                 ]
+                              },
+                              "isKeyField": {
+                                "type": "boolean"
                               }
                             }
                           }
+                        },
+                        "conditions": {
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Persisted AND/OR monitoring condition group"
                         }
                       },
-                      "description": "Monitoring configuration"
+                      "description": "Current monitoring configuration. Use these values as the basis for replacement updates."
                     },
                     "openSupportRequests": {
                       "type": "array",
@@ -2232,6 +2299,15 @@
                         }
                       }
                     },
+                    "extractionStrategySummary": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ExtractionStrategySummary"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Customer-safe extraction strategy for custom SCRIPT workflows without an Assistant build. Omitted for Assistant-owned workflows, whose current strategy is available from the Agent strategy endpoint."
+                    },
                     "assistantSessionId": {
                       "type": "string",
                       "nullable": true,
@@ -2244,7 +2320,7 @@
                     },
                     "assistantEligible": {
                       "type": "boolean",
-                      "description": "True when this workflow has no assistant session yet and is eligible to start one (SHELLY_SCRIPT and SHELLY_REAL_TIME_SCRIPT workflows)."
+                      "description": "True when this workflow's lane supports the assistant (SHELLY_SCRIPT or SHELLY_REAL_TIME_SCRIPT). Independent of assistantSessionId; combine with !assistantSessionId for start-vs-continue."
                     },
                     "sessionStatus": {
                       "type": "string",
@@ -2262,15 +2338,6 @@
                         "timed_out"
                       ],
                       "description": "Status of the linked assistant session. Useful for deciding whether the Assistant can accept new input (failed/errored/aborted/timed_out are closed)."
-                    },
-                    "extractionStrategySummary": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/ExtractionStrategySummary"
-                        }
-                      ],
-                      "nullable": true,
-                      "description": "Customer-safe extraction strategy for custom SCRIPT workflows without an Assistant build. Omitted for Assistant-owned workflows, whose current strategy is available from the Agent strategy endpoint."
                     }
                   }
                 }
@@ -4262,17 +4329,31 @@
                   },
                   "limit": {
                     "type": "integer",
-                    "description": "The new limit for the workflow"
+                    "minimum": 1,
+                    "nullable": true,
+                    "description": "Maximum records per run. Pass null to clear the limit and extract all rows."
                   },
                   "updateInterval": {
                     "type": "string",
                     "description": "The new update interval for the workflow",
                     "enum": [
                       "ONLY_ONCE",
+                      "EVERY_10_MINUTES",
+                      "HALF_HOURLY",
                       "HOURLY",
+                      "THREE_HOURLY",
+                      "SIX_HOURLY",
+                      "TWELVE_HOURLY",
+                      "EIGHTEEN_HOURLY",
                       "DAILY",
+                      "TWO_DAY",
+                      "THREE_DAY",
                       "WEEKLY",
+                      "BIWEEKLY",
+                      "TRIWEEKLY",
+                      "FOUR_WEEKS",
                       "MONTHLY",
+                      "REAL_TIME",
                       "CUSTOM"
                     ]
                   },
@@ -4282,6 +4363,11 @@
                       "type": "string"
                     },
                     "description": "Array of cron expressions for the workflow schedule"
+                  },
+                  "timezone": {
+                    "type": "string",
+                    "example": "America/New_York",
+                    "description": "IANA timezone for cron schedules. A timezone-only update preserves existing cron expressions."
                   },
                   "name": {
                     "type": "string",
@@ -4322,15 +4408,24 @@
                   },
                   "monitoring": {
                     "type": "object",
+                    "required": [
+                      "fields"
+                    ],
                     "description": "The monitoring config for the workflow",
                     "properties": {
                       "fields": {
                         "type": "array",
+                        "minItems": 1,
                         "items": {
                           "type": "object",
+                          "required": [
+                            "fieldName",
+                            "operator"
+                          ],
                           "properties": {
                             "fieldName": {
                               "type": "string",
+                              "minLength": 1,
                               "description": "The name of the field to monitor"
                             },
                             "operator": {
@@ -4341,12 +4436,20 @@
                                 "removed"
                               ],
                               "description": "The operator to use for monitoring"
+                            },
+                            "isKeyField": {
+                              "type": "boolean",
+                              "description": "Optional explicit schema-key update for this field"
                             }
                           }
                         }
                       },
                       "conditions": {
                         "type": "object",
+                        "required": [
+                          "logicalOperator",
+                          "conditions"
+                        ],
                         "description": "The conditions for monitoring",
                         "properties": {
                           "logicalOperator": {
@@ -4359,8 +4462,13 @@
                           },
                           "conditions": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                               "type": "object",
+                              "required": [
+                                "type",
+                                "operator"
+                              ],
                               "properties": {
                                 "type": {
                                   "type": "string",
@@ -4376,11 +4484,43 @@
                                 },
                                 "operator": {
                                   "type": "string",
+                                  "enum": [
+                                    "MATCHES_REGEX",
+                                    "EQUALS",
+                                    "NOT_EQUALS",
+                                    "CONTAINS",
+                                    "NOT_CONTAINS",
+                                    "STARTS_WITH",
+                                    "ENDS_WITH",
+                                    "GREATER_THAN",
+                                    "LESS_THAN",
+                                    "GREATER_THAN_OR_EQUAL",
+                                    "LESS_THAN_OR_EQUAL",
+                                    "IN",
+                                    "NOT_IN",
+                                    "BEFORE",
+                                    "AFTER",
+                                    "WITHIN_LAST_DAYS",
+                                    "IS_NULL",
+                                    "IS_NOT_NULL",
+                                    "IS_EMPTY",
+                                    "IS_NOT_EMPTY"
+                                  ],
                                   "description": "Condition operator"
                                 },
                                 "value": {
-                                  "type": "string",
-                                  "description": "Value to compare against"
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ],
+                                  "description": "Required except for null/empty operators"
                                 }
                               }
                             }
@@ -4464,10 +4604,6 @@
                     },
                     "message": {
                       "type": "string"
-                    },
-                    "deprecationNotice": {
-                      "type": "string",
-                      "description": "Optional deprecation notice for legacy navigation modes"
                     }
                   }
                 }

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -2262,6 +2262,15 @@
                         "timed_out"
                       ],
                       "description": "Status of the linked assistant session. Useful for deciding whether the Assistant can accept new input (failed/errored/aborted/timed_out are closed)."
+                    },
+                    "extractionStrategySummary": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ExtractionStrategySummary"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Customer-safe extraction strategy for custom SCRIPT workflows without an Assistant build. Omitted for Assistant-owned workflows, whose current strategy is available from the Agent strategy endpoint."
                     }
                   }
                 }
@@ -17899,6 +17908,175 @@
           }
         ]
       }
+    },
+    "/v5/agent/workflows/{workflowId}/assistant/messages": {
+      "post": {
+        "operationId": "v5AgentWorkflowAssistantMessage",
+        "summary": "Request an Assistant update to an existing workflow",
+        "description": "Bootstraps or reuses the workflow's customer Assistant session and enqueues update instructions without changing the workflow ID.",
+        "tags": [
+          "Agent"
+        ],
+        "parameters": [
+          {
+            "name": "workflowId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowAssistantMessageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Workflow Assistant update accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowAssistantMessageResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid workflow ID or request body"
+          },
+          "404": {
+            "description": "Workflow or Assistant session not found"
+          },
+          "409": {
+            "description": "Assistant session or thread conflict"
+          }
+        }
+      }
+    },
+    "/v5/agent/{sessionId}/pause-state": {
+      "get": {
+        "operationId": "v5AgentPauseState",
+        "summary": "Get durable Assistant pause and question state",
+        "tags": [
+          "Agent"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Assistant pause state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantPauseStateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found"
+          },
+          "409": {
+            "description": "Invalid session pause state"
+          },
+          "503": {
+            "description": "Assistant manager temporarily unavailable"
+          }
+        }
+      }
+    },
+    "/v5/agent/answer": {
+      "post": {
+        "operationId": "v5AgentAnswer",
+        "summary": "Answer a durable Assistant question",
+        "tags": [
+          "Agent"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssistantAnswerRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Answer accepted and session resume requested",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantAnswerResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "404": {
+            "description": "Session or question not found"
+          },
+          "409": {
+            "description": "Question has already resumed or cannot accept an answer"
+          }
+        }
+      }
+    },
+    "/v5/agent/data/{sessionId}/strategy": {
+      "get": {
+        "operationId": "v5AgentStrategy",
+        "summary": "Get the latest customer-safe Assistant extraction strategy",
+        "description": "Returns strategy null when the session exists but no build strategy is available yet.",
+        "tags": [
+          "Agent"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Latest extraction strategy, or null while unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantStrategyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -25912,6 +26090,367 @@
         ],
         "title": "WorkflowCreateRequest",
         "description": "Create a workflow using natural-language instructions. Navigation is handled automatically for new integrations."
+      },
+      "ExtractionStrategySummary": {
+        "type": "object",
+        "required": [
+          "approach",
+          "summary",
+          "dataSource"
+        ],
+        "properties": {
+          "approach": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "dataSource": {
+            "type": "object",
+            "required": [
+              "type",
+              "endpoints",
+              "interactionStyle",
+              "selectors"
+            ],
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "endpoints": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "interactionStyle": {
+                "type": "string"
+              },
+              "selectors": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "intervalSeconds": {
+            "type": "number",
+            "nullable": true,
+            "description": "Realtime polling interval in seconds, when applicable."
+          }
+        }
+      },
+      "AssistantQuestion": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "question",
+          "header",
+          "options",
+          "answerType"
+        ],
+        "properties": {
+          "question": {
+            "type": "string"
+          },
+          "header": {
+            "type": "string"
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "label",
+                "description"
+              ],
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "answerType": {
+            "type": "string",
+            "enum": [
+              "single",
+              "multi",
+              "freeform"
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "WorkflowAssistantMessageRequest": {
+        "type": "object",
+        "required": [
+          "prompt"
+        ],
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Natural-language instructions for updating the existing workflow."
+          },
+          "threadId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "Assistant thread to continue. Omit to use the workflow's latest Assistant thread."
+          }
+        }
+      },
+      "WorkflowAssistantMessageResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status",
+          "message"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "jobId",
+              "sessionId",
+              "threadId",
+              "workflowId"
+            ],
+            "properties": {
+              "jobId": {
+                "type": "string",
+                "nullable": true
+              },
+              "inputEventId": {
+                "type": "string"
+              },
+              "sessionId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "threadId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "workflowId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "existed": {
+                "type": "boolean"
+              },
+              "alreadyBootstrapped": {
+                "type": "boolean"
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "AssistantPauseStateResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "paused",
+              "pause",
+              "pendingQuestion"
+            ],
+            "properties": {
+              "paused": {
+                "type": "boolean"
+              },
+              "pause": {
+                "type": "object",
+                "nullable": true,
+                "required": [
+                  "id",
+                  "reason",
+                  "status",
+                  "pausedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string",
+                    "enum": [
+                      "question",
+                      "interrupt"
+                    ]
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "resuming"
+                    ]
+                  },
+                  "threadId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "pausedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "resumeRequestedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "pendingQuestion": {
+                "type": "object",
+                "nullable": true,
+                "required": [
+                  "questionId",
+                  "questions",
+                  "askedAt"
+                ],
+                "properties": {
+                  "questionId": {
+                    "type": "string"
+                  },
+                  "threadId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "questions": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/AssistantQuestion"
+                    }
+                  },
+                  "askedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          }
+        }
+      },
+      "AssistantAnswerRequest": {
+        "type": "object",
+        "required": [
+          "sessionId",
+          "questionId",
+          "answers"
+        ],
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "questionId": {
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "answers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Question-index-to-answer map. Freeform answers use the `_freeform` key."
+          }
+        }
+      },
+      "AssistantAnswerResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status",
+          "message"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "success"
+            ],
+            "properties": {
+              "success": {
+                "type": "boolean",
+                "enum": [
+                  true
+                ]
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "AssistantStrategyResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "strategy"
+            ],
+            "properties": {
+              "strategy": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExtractionStrategySummary"
+                  }
+                ],
+                "nullable": true
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          }
+        }
       }
     },
     "securitySchemes": {


### PR DESCRIPTION
## Summary
- import the Bundle B workflow detail and metadata-update OpenAPI operations
- type canonical Assistant/template/health detail fields
- type location, timezone, monitoring, and `limit: null` updates
- verify the SDK forwards nullable and deterministic settings unchanged

## Stack
Depends on #345 and the stacked backend contract PR.

## Verification
- Node SDK typecheck
- 10 focused Assistant/workflow-management tests
- Node SDK build

Linear: KAD-17778, KAD-17780, KAD-7997
