### PR TITLE
feat(node-sdk): add assistant session controls

### DIFF
--- a/sdks/node/src/domains/assistant/assistant.acl.ts
+++ b/sdks/node/src/domains/assistant/assistant.acl.ts
@@ -1,10 +1,12 @@
 import type {
   AgentApiInterface,
   AssistantAnswerResponseData,
+  AssistantControlResponseData,
   AssistantPauseStateResponseData,
   AssistantPauseStateResponseDataPause,
   AssistantPauseStateResponseDataPendingQuestion,
   AssistantQuestion,
+  AssistantResumeResponseData,
   ExtractionStrategySummary,
   WorkflowAssistantMessageResponseData,
 } from "../../generated";
@@ -36,3 +38,5 @@ export interface AssistantQuestionAnswerInput {
 
 export type AssistantQuestionAnswerResult = AssistantAnswerResponseData;
 export type AssistantExtractionStrategy = ExtractionStrategySummary;
+export type AssistantControlResult = AssistantControlResponseData;
+export type AssistantResumeAccepted = AssistantResumeResponseData;

--- a/sdks/node/src/domains/assistant/assistant.service.ts
+++ b/sdks/node/src/domains/assistant/assistant.service.ts
@@ -1,10 +1,12 @@
 import { KadoaSdkException } from "../../runtime/exceptions";
 import type {
   AgentApiInterface,
+  AssistantControlResult,
   AssistantExtractionStrategy,
   AssistantPauseState,
   AssistantQuestionAnswerInput,
   AssistantQuestionAnswerResult,
+  AssistantResumeAccepted,
   WorkflowAssistantUpdateAccepted,
   WorkflowAssistantUpdateInput,
 } from "./assistant.acl";
@@ -62,5 +64,20 @@ export class AssistantService {
   ): Promise<AssistantExtractionStrategy | null> {
     const response = await this.agentApi.v5AgentStrategy({ sessionId });
     return response.data.data.strategy;
+  }
+
+  async interrupt(sessionId: string): Promise<AssistantControlResult> {
+    const response = await this.agentApi.v5AgentInterrupt({ sessionId });
+    return response.data.data;
+  }
+
+  async resume(sessionId: string): Promise<AssistantResumeAccepted> {
+    const response = await this.agentApi.v5AgentResume({ sessionId });
+    return response.data.data;
+  }
+
+  async stop(sessionId: string): Promise<AssistantControlResult> {
+    const response = await this.agentApi.v5AgentStop({ sessionId });
+    return response.data.data;
   }
 }

--- a/sdks/node/test/unit/assistant.service.test.ts
+++ b/sdks/node/test/unit/assistant.service.test.ts
@@ -11,14 +11,21 @@ const mockUpdate = mock();
 const mockPauseState = mock();
 const mockAnswer = mock();
 const mockStrategy = mock();
+const mockInterrupt = mock();
+const mockResume = mock();
+const mockStop = mock();
 
 function createTestClient(): KadoaClient {
   const client = new KadoaClient({ apiKey: "tk-test" });
-  const agent = (client.apis as any).agent;
-  agent.v5AgentWorkflowAssistantMessage = mockUpdate;
-  agent.v5AgentPauseState = mockPauseState;
-  agent.v5AgentAnswer = mockAnswer;
-  agent.v5AgentStrategy = mockStrategy;
+  Object.assign(client.apis.agent, {
+    v5AgentWorkflowAssistantMessage: mockUpdate,
+    v5AgentPauseState: mockPauseState,
+    v5AgentAnswer: mockAnswer,
+    v5AgentStrategy: mockStrategy,
+    v5AgentInterrupt: mockInterrupt,
+    v5AgentResume: mockResume,
+    v5AgentStop: mockStop,
+  });
   return client;
 }
 
@@ -74,6 +81,9 @@ describe("AssistantService", () => {
     mockPauseState.mockReset();
     mockAnswer.mockReset();
     mockStrategy.mockReset();
+    mockInterrupt.mockReset();
+    mockResume.mockReset();
+    mockStop.mockReset();
   });
 
   test("requests an identity-preserving workflow update", async () => {
@@ -204,6 +214,56 @@ describe("AssistantService", () => {
     expect(
       await createTestClient().assistant.getStrategy(updateData.sessionId),
     ).toBeNull();
+  });
+
+  test("interrupts an Assistant session and preserves delivery state", async () => {
+    mockInterrupt.mockResolvedValueOnce({
+      data: { data: { success: true, delivery: "durable" }, status: "success" },
+    });
+
+    const result = await createTestClient().assistant.interrupt(
+      updateData.sessionId,
+    );
+
+    expect(mockInterrupt).toHaveBeenCalledWith({
+      sessionId: updateData.sessionId,
+    });
+    expect(result).toEqual({ success: true, delivery: "durable" });
+  });
+
+  test("resumes an Assistant session and returns the new execution", async () => {
+    mockResume.mockResolvedValueOnce({
+      data: {
+        data: { sessionId: updateData.sessionId, jobId: "resume-job-1" },
+        status: "success",
+        message: "Session resume started",
+      },
+    });
+
+    const result = await createTestClient().assistant.resume(
+      updateData.sessionId,
+    );
+
+    expect(mockResume).toHaveBeenCalledWith({
+      sessionId: updateData.sessionId,
+    });
+    expect(result).toEqual({
+      sessionId: updateData.sessionId,
+      jobId: "resume-job-1",
+    });
+  });
+
+  test("stops an Assistant session", async () => {
+    mockStop.mockResolvedValueOnce({
+      data: { data: { success: true }, status: "success" },
+    });
+
+    const result = await createTestClient().assistant.stop(
+      updateData.sessionId,
+    );
+
+    expect(mockStop).toHaveBeenCalledWith({ sessionId: updateData.sessionId });
+    expect(result).toEqual({ success: true });
   });
 
   test("propagates generated API errors", async () => {

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -18222,6 +18222,121 @@
           }
         }
       }
+    },
+    "/v5/agent/{sessionId}/interrupt": {
+      "post": {
+        "operationId": "v5AgentInterrupt",
+        "summary": "Safely interrupt an active Assistant session",
+        "tags": [
+          "Agent"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Interrupt accepted or the session was already paused",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantControlResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found for the authenticated team"
+          },
+          "409": {
+            "description": "Session cannot be interrupted from its current state"
+          }
+        }
+      }
+    },
+    "/v5/agent/{sessionId}/resume": {
+      "post": {
+        "operationId": "v5AgentResume",
+        "summary": "Resume an inactive or interrupted Assistant session",
+        "description": "Resumes with the persona persisted on the session, preserving Lighthouse versus Julie behavior.",
+        "tags": [
+          "Agent"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resume accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantResumeResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found for the authenticated team"
+          },
+          "409": {
+            "description": "Session is already active or cannot be resumed"
+          }
+        }
+      }
+    },
+    "/v5/agent/{sessionId}/stop": {
+      "post": {
+        "operationId": "v5AgentStop",
+        "summary": "Stop an active Assistant session",
+        "tags": [
+          "Agent"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stop accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantControlResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found for the authenticated team"
+          },
+          "409": {
+            "description": "Session is not active"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -26594,6 +26709,74 @@
             "enum": [
               "success"
             ]
+          }
+        }
+      },
+      "AssistantControlResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "success"
+            ],
+            "properties": {
+              "success": {
+                "type": "boolean"
+              },
+              "delivery": {
+                "type": "string",
+                "enum": [
+                  "durable",
+                  "already_paused"
+                ]
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          }
+        }
+      },
+      "AssistantResumeResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status",
+          "message"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "jobId",
+              "sessionId"
+            ],
+            "properties": {
+              "jobId": {
+                "type": "string"
+              },
+              "sessionId": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          },
+          "message": {
+            "type": "string"
           }
         }
       }


### PR DESCRIPTION
## Summary
- generate typed Agent interrupt, resume, and stop operations
- add `client.assistant.interrupt`, `resume`, and `stop`
- expose typed control and resume results

## Stack
Depends on #346 and its backend stack.

## Verification
- Node SDK typecheck and build
- 13 focused Assistant/workflow-management tests

Linear: KAD-17777
