### PR TITLE
fix(spec): unblock Node SDK 0.37 publication

### DIFF
--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -2338,15 +2338,6 @@
                         "timed_out"
                       ],
                       "description": "Status of the linked assistant session. Useful for deciding whether the Assistant can accept new input (failed/errored/aborted/timed_out are closed)."
-                    },
-                    "extractionStrategySummary": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/ExtractionStrategySummary"
-                        }
-                      ],
-                      "nullable": true,
-                      "description": "Customer-safe extraction strategy for custom SCRIPT workflows without an Assistant build. Omitted for Assistant-owned workflows, whose current strategy is available from the Agent strategy endpoint."
                     }
                   }
                 }


### PR DESCRIPTION
## Summary
- remove the duplicate `extractionStrategySummary` JSON key introduced while combining the Assistant lifecycle and workflow parity specs
- restore OpenAPI Generator parsing so the Node SDK release workflow can publish

## Context
The `node-sdk-v0.37.0` release workflow failed before npm publication because Jackson rejects duplicate JSON keys. npm therefore still serves 0.36.0, blocking the MCP merge chain.

## Verification
- `bun kadoa-codegen generate -c node`
- Node SDK typecheck
- Node SDK build
- 13/13 focused Assistant/workflow-management tests
