### PR TITLE
fix(node-sdk): guard release OpenAPI source

### DIFF
--- a/sdks/node/test/unit/openapi-spec.test.ts
+++ b/sdks/node/test/unit/openapi-spec.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const specPath = new URL("../../../../specs/openapi.json", import.meta.url);
+
+describe("published OpenAPI source", () => {
+  test("is valid JSON without a duplicate workflow strategy field", () => {
+    const source = readFileSync(specPath, "utf8");
+
+    expect(() => JSON.parse(source)).not.toThrow();
+    expect(source.match(/"extractionStrategySummary"\s*:/g)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Node SDK regression test that rejects malformed JSON and duplicate `extractionStrategySummary` properties
- ensure Release Please sees the publication fix inside the `sdks/node` component and creates the required patch release

## Context
The 0.37.0 GitHub release exists, but its npm publication failed during codegen. PR #349 fixed the root spec; Release Please correctly ignored that root-only commit for the path-scoped Node component, so this Node-side regression guard is required to trigger 0.37.1.

## Verification
- regression test passes
- Node SDK typecheck passes
- Biome passes
