### PR TITLE
KAD-17771: add typed Julie realtime creation

### DIFF
--- a/sdks/node/src/domains/assistant/assistant.acl.ts
+++ b/sdks/node/src/domains/assistant/assistant.acl.ts
@@ -1,5 +1,6 @@
 import type {
   AgentApiInterface,
+  AgentPromptResponseData,
   AssistantAnswerResponseData,
   AssistantControlResponseData,
   AssistantPauseStateResponseData,
@@ -15,11 +16,19 @@ export type { AgentApiInterface };
 
 export const FREEFORM_ASSISTANT_ANSWER_KEY = "_freeform" as const;
 
+export interface CreateRealtimeWorkflowInput {
+  instructions: string;
+  notificationChannelIds: string[];
+  tags?: string[];
+  newSessionId?: string;
+}
+
 export interface WorkflowAssistantUpdateInput {
   instructions: string;
   threadId?: string;
 }
 
+export type RealtimeWorkflowCreationAccepted = AgentPromptResponseData;
 export type WorkflowAssistantUpdateAccepted =
   WorkflowAssistantMessageResponseData;
 export type AssistantPauseState = AssistantPauseStateResponseData;

--- a/sdks/node/src/domains/assistant/assistant.service.ts
+++ b/sdks/node/src/domains/assistant/assistant.service.ts
@@ -7,12 +7,48 @@ import type {
   AssistantQuestionAnswerInput,
   AssistantQuestionAnswerResult,
   AssistantResumeAccepted,
+  CreateRealtimeWorkflowInput,
+  RealtimeWorkflowCreationAccepted,
   WorkflowAssistantUpdateAccepted,
   WorkflowAssistantUpdateInput,
 } from "./assistant.acl";
 
 export class AssistantService {
   constructor(private readonly agentApi: AgentApiInterface) {}
+
+  async createRealtimeWorkflow(
+    input: CreateRealtimeWorkflowInput,
+  ): Promise<RealtimeWorkflowCreationAccepted> {
+    const response = await this.agentApi.v5AgentPrompt({
+      agentPromptRequest: {
+        prompt: input.instructions,
+        productType: "realtime",
+        notificationChannelIds:
+          input.notificationChannelIds as unknown as Set<string>,
+        ...(input.tags != null && { tags: input.tags }),
+        ...(input.newSessionId != null && { newSessionId: input.newSessionId }),
+      },
+    });
+    const data = response.data?.data;
+
+    if (
+      !data?.workflowId ||
+      !data.sessionId ||
+      !data.threadId ||
+      !Object.keys(data ?? {}).includes("jobId") ||
+      data.jobId === undefined
+    ) {
+      throw new KadoaSdkException(
+        "Realtime Assistant creation response is missing required identifiers",
+        {
+          code: "INTERNAL_ERROR",
+          details: { response: response.data },
+        },
+      );
+    }
+
+    return data;
+  }
 
   async requestWorkflowUpdate(
     workflowId: string,

--- a/sdks/node/src/domains/assistant/index.ts
+++ b/sdks/node/src/domains/assistant/index.ts
@@ -8,7 +8,9 @@ export {
   type AssistantQuestionAnswerInput,
   type AssistantQuestionAnswerResult,
   type AssistantQuestionAnswers,
+  type CreateRealtimeWorkflowInput,
   FREEFORM_ASSISTANT_ANSWER_KEY,
+  type RealtimeWorkflowCreationAccepted,
   type WorkflowAssistantUpdateAccepted,
   type WorkflowAssistantUpdateInput,
 } from "./assistant.acl";

--- a/sdks/node/src/domains/changes/changes.acl.ts
+++ b/sdks/node/src/domains/changes/changes.acl.ts
@@ -24,7 +24,7 @@ export interface Change {
   /** ID of the workflow this change belongs to */
   workflowId?: string;
   /** Current state of the data after the change */
-  data?: Array<object>;
+  data?: Array<object> | null;
   /** Structured representation of changes with object-based diffing */
   differences?: ChangeDifference[];
   /** URL where the change was detected */

--- a/sdks/node/src/domains/workflows/workflows-core.service.ts
+++ b/sdks/node/src/domains/workflows/workflows-core.service.ts
@@ -1,8 +1,16 @@
 import { KadoaSdkException } from "../../runtime/exceptions";
 import { ERROR_MESSAGES } from "../../runtime/exceptions/base.exception";
 import { logger } from "../../runtime/logger";
-import { type PollingOptions, pollUntil, validateAdditionalData } from "../../runtime/utils";
-import type { LocationConfig, SchemaField, WorkflowInterval } from "../extraction/extraction.acl";
+import {
+  type PollingOptions,
+  pollUntil,
+  validateAdditionalData,
+} from "../../runtime/utils";
+import type {
+  LocationConfig,
+  SchemaField,
+  WorkflowInterval,
+} from "../extraction/extraction.acl";
 import type { TemplatesService } from "../templates/templates.service";
 import {
   type GetJobResponse,
@@ -127,10 +135,13 @@ export class WorkflowsCoreService {
         );
       }
     } else if (!input.userPrompt) {
-      throw new KadoaSdkException("userPrompt is required to create a workflow", {
-        code: "VALIDATION_ERROR",
-        details: { urls: input.urls },
-      });
+      throw new KadoaSdkException(
+        "userPrompt is required to create a workflow",
+        {
+          code: "VALIDATION_ERROR",
+          details: { urls: input.urls },
+        },
+      );
     }
 
     const domainName = new URL(input.urls[0]).hostname;
@@ -138,7 +149,8 @@ export class WorkflowsCoreService {
     let request: PromptWorkflow | WorkflowFromTemplate;
     if (isFromTemplate) {
       const templateId = input.templateId as string;
-      const templateVersion = input.templateVersion ?? (await this.resolveLatestVersion(templateId));
+      const templateVersion =
+        input.templateVersion ?? (await this.resolveLatestVersion(templateId));
 
       request = {
         urls: input.urls,
@@ -205,7 +217,8 @@ export class WorkflowsCoreService {
       );
     }
     const template = await this.templatesService.get(templateId);
-    const latest = (template as { latestVersion?: number | null }).latestVersion;
+    const latest = (template as { latestVersion?: number | null })
+      .latestVersion;
     if (latest == null) {
       throw new KadoaSdkException(
         `Template ${templateId} has no published versions; supply templateVersion explicitly or publish a version first.`,
@@ -226,7 +239,18 @@ export class WorkflowsCoreService {
   }
 
   async list(filters?: ListWorkflowsRequest): Promise<WorkflowResponse[]> {
-    const response = await this.workflowsApi.v4WorkflowsGet(filters);
+    if (filters == null) {
+      const response = await this.workflowsApi.v4WorkflowsGet();
+      return (response.data?.workflows ?? []) as WorkflowResponse[];
+    }
+
+    const { templateId, ...rest } = filters;
+    const response = await this.workflowsApi.v4WorkflowsGet({
+      ...rest,
+      ...(templateId != null && {
+        templateId: Array.isArray(templateId) ? templateId : [templateId],
+      }),
+    });
     return (response.data?.workflows ?? []) as WorkflowResponse[];
   }
 
@@ -243,7 +267,10 @@ export class WorkflowsCoreService {
    * (UI/API/SDK/MCP/CLI/SYSTEM), and full before/after snapshots for UPDATE
    * operations. CREATE entries have null `previousValue`/`newValue`.
    */
-  async getAuditLog(id: WorkflowId, options?: WorkflowAuditLogOptions): Promise<WorkflowAuditLogResponse> {
+  async getAuditLog(
+    id: WorkflowId,
+    options?: WorkflowAuditLogOptions,
+  ): Promise<WorkflowAuditLogResponse> {
     const response = await this.workflowsApi.v5WorkflowsWorkflowIdAuditlogGet({
       workflowId: id,
       page: options?.page,
@@ -256,7 +283,10 @@ export class WorkflowsCoreService {
    * Get the run history for a workflow, optionally filtered by outcome
    * (success | failed | in_progress) and paginated.
    */
-  async listWorkflowRuns(id: WorkflowId, options?: WorkflowRunsOptions): Promise<WorkflowRunsResponse> {
+  async listWorkflowRuns(
+    id: WorkflowId,
+    options?: WorkflowRunsOptions,
+  ): Promise<WorkflowRunsResponse> {
     const response = await this.workflowsApi.v4WorkflowsWorkflowIdHistoryGet({
       workflowId: id,
       page: options?.page,
@@ -272,7 +302,10 @@ export class WorkflowsCoreService {
     });
   }
 
-  async update(id: WorkflowId, input: UpdateWorkflowRequest): Promise<UpdateWorkflowResponse> {
+  async update(
+    id: WorkflowId,
+    input: UpdateWorkflowRequest,
+  ): Promise<UpdateWorkflowResponse> {
     validateAdditionalData(input.additionalData);
 
     const response = await this.workflowsApi.v4WorkflowsWorkflowIdMetadataPut({
@@ -297,7 +330,10 @@ export class WorkflowsCoreService {
   /**
    * Wait for a workflow to reach the target state or a terminal state if no target state is provided
    */
-  async wait(id: WorkflowId, options?: WaitOptions): Promise<GetWorkflowResponse> {
+  async wait(
+    id: WorkflowId,
+    options?: WaitOptions,
+  ): Promise<GetWorkflowResponse> {
     const result = await pollUntil(
       async () => {
         const current = await this.get(id);
@@ -313,7 +349,11 @@ export class WorkflowsCoreService {
         }
 
         // Check for terminal states
-        if (current.runState && TERMINAL_RUN_STATES.has(current.runState.toUpperCase()) && current.state !== "QUEUED") {
+        if (
+          current.runState &&
+          TERMINAL_RUN_STATES.has(current.runState.toUpperCase()) &&
+          current.state !== "QUEUED"
+        ) {
           return true;
         }
 
@@ -328,7 +368,10 @@ export class WorkflowsCoreService {
   /**
    * Run a workflow with variables and optional limit
    */
-  async runWorkflow(workflowId: WorkflowId, input: RunWorkflowRequest): Promise<RunWorkflowResponse> {
+  async runWorkflow(
+    workflowId: WorkflowId,
+    input: RunWorkflowRequest,
+  ): Promise<RunWorkflowResponse> {
     const response = await this.workflowsApi.v4WorkflowsWorkflowIdRunPut({
       workflowId,
       v4WorkflowsWorkflowIdRunPutRequest: {
@@ -357,7 +400,10 @@ export class WorkflowsCoreService {
   /**
    * Get job status directly without polling workflow details
    */
-  async getJobStatus(workflowId: WorkflowId, jobId: JobId): Promise<GetJobResponse> {
+  async getJobStatus(
+    workflowId: WorkflowId,
+    jobId: JobId,
+  ): Promise<GetJobResponse> {
     const response = await this.workflowsApi.v4WorkflowsWorkflowIdJobsJobIdGet({
       workflowId,
       jobId,
@@ -368,7 +414,11 @@ export class WorkflowsCoreService {
   /**
    * Wait for a job to reach the target state or a terminal state
    */
-  async waitForJobCompletion(workflowId: WorkflowId, jobId: JobId, options?: JobWaitOptions): Promise<GetJobResponse> {
+  async waitForJobCompletion(
+    workflowId: WorkflowId,
+    jobId: JobId,
+    options?: JobWaitOptions,
+  ): Promise<GetJobResponse> {
     const result = await pollUntil(
       async () => {
         const current = await this.getJobStatus(workflowId, jobId);

--- a/sdks/node/src/domains/workflows/workflows.acl.ts
+++ b/sdks/node/src/domains/workflows/workflows.acl.ts
@@ -29,7 +29,6 @@ import type {
   V4WorkflowsWorkflowIdRunPutRequest,
   WorkflowFromTemplate,
   WorkflowsApiInterface,
-  WorkflowsApiV4WorkflowsGetRequest,
   WorkflowWithEntityAndFields,
   WorkflowWithExistingSchema,
 } from "../../generated";
@@ -90,6 +89,7 @@ export const UpdateInterval = {
   Daily: "DAILY",
   Weekly: "WEEKLY",
   Monthly: "MONTHLY",
+  RealTime: "REAL_TIME",
 } as const satisfies Record<
   keyof typeof V4WorkflowsGetUpdateIntervalEnum,
   V4WorkflowsGetUpdateIntervalEnum
@@ -190,7 +190,7 @@ export type JobStateEnum = (typeof JobStateEnum)[keyof typeof JobStateEnum];
 // Request Types
 // ========================================
 
-export class ListWorkflowsRequest implements WorkflowsApiV4WorkflowsGetRequest {
+export class ListWorkflowsRequest {
   search?: string;
   skip?: number;
   limit?: number;
@@ -198,7 +198,7 @@ export class ListWorkflowsRequest implements WorkflowsApiV4WorkflowsGetRequest {
   tags?: Array<string>;
   monitoring?: MonitoringStatus;
   updateInterval?: UpdateInterval;
-  templateId?: string;
+  templateId?: string | string[];
   includeDeleted?: IncludeDeleted;
   format?: ResponseFormat;
 }
@@ -320,7 +320,8 @@ export type WorkflowRunState = NonNullable<WorkflowRun["state"]>;
 /**
  * Semantic status filter accepted by `listWorkflowRuns`.
  */
-export const WorkflowRunStatusFilter = V4WorkflowsWorkflowIdHistoryGetStatusEnum;
+export const WorkflowRunStatusFilter =
+  V4WorkflowsWorkflowIdHistoryGetStatusEnum;
 
 export type WorkflowRunStatusFilter =
   (typeof WorkflowRunStatusFilter)[keyof typeof WorkflowRunStatusFilter];

--- a/sdks/node/test/unit/assistant.service.test.ts
+++ b/sdks/node/test/unit/assistant.service.test.ts
@@ -7,6 +7,7 @@ mock.module("../../src/runtime/utils/version-check", () => ({
 import { KadoaClient } from "../../src/client/kadoa-client";
 import { KadoaSdkException } from "../../src/runtime/exceptions";
 
+const mockPrompt = mock();
 const mockUpdate = mock();
 const mockPauseState = mock();
 const mockAnswer = mock();
@@ -18,6 +19,7 @@ const mockStop = mock();
 function createTestClient(): KadoaClient {
   const client = new KadoaClient({ apiKey: "tk-test" });
   Object.assign(client.apis.agent, {
+    v5AgentPrompt: mockPrompt,
     v5AgentWorkflowAssistantMessage: mockUpdate,
     v5AgentPauseState: mockPauseState,
     v5AgentAnswer: mockAnswer,
@@ -28,6 +30,15 @@ function createTestClient(): KadoaClient {
   });
   return client;
 }
+
+const createData = {
+  workflowId: "11111111-1111-4111-8111-111111111111",
+  sessionId: "22222222-2222-4222-8222-222222222222",
+  threadId: "33333333-3333-4333-8333-333333333333",
+  jobId: "job-1",
+  inputEventId: "event-1",
+  existed: false,
+};
 
 const updateData = {
   workflowId: "11111111-1111-4111-8111-111111111111",
@@ -77,6 +88,7 @@ const strategy = {
 
 describe("AssistantService", () => {
   beforeEach(() => {
+    mockPrompt.mockReset();
     mockUpdate.mockReset();
     mockPauseState.mockReset();
     mockAnswer.mockReset();
@@ -84,6 +96,94 @@ describe("AssistantService", () => {
     mockInterrupt.mockReset();
     mockResume.mockReset();
     mockStop.mockReset();
+  });
+
+  test("creates a realtime workflow through the agent prompt API", async () => {
+    mockPrompt.mockResolvedValueOnce({
+      data: {
+        data: createData,
+        status: "success",
+        message: "Agent prompt accepted",
+      },
+    });
+    const client = createTestClient();
+
+    const result = await client.assistant.createRealtimeWorkflow({
+      instructions: "Monitor https://example.com for price changes",
+      notificationChannelIds: ["11111111-1111-4111-8111-111111111111"],
+      tags: ["mcp"],
+      newSessionId: "22222222-2222-4222-8222-222222222222",
+    });
+
+    expect(mockPrompt).toHaveBeenCalledWith({
+      agentPromptRequest: {
+        prompt: "Monitor https://example.com for price changes",
+        productType: "realtime",
+        notificationChannelIds: ["11111111-1111-4111-8111-111111111111"],
+        tags: ["mcp"],
+        newSessionId: "22222222-2222-4222-8222-222222222222",
+      },
+    });
+    expect(result).toEqual(createData);
+  });
+
+  test("preserves a nullable realtime creation job id", async () => {
+    mockPrompt.mockResolvedValueOnce({
+      data: {
+        data: { ...createData, jobId: null },
+        status: "success",
+        message: "Agent prompt accepted",
+      },
+    });
+
+    const result = await createTestClient().assistant.createRealtimeWorkflow({
+      instructions: "Monitor https://example.com for price changes",
+      notificationChannelIds: ["11111111-1111-4111-8111-111111111111"],
+    });
+
+    expect(result.jobId).toBeNull();
+  });
+
+  test.each([
+    ["workflowId", { ...createData, workflowId: "" }],
+    ["sessionId", { ...createData, sessionId: "" }],
+    ["threadId", { ...createData, threadId: "" }],
+    [
+      "jobId",
+      (() => {
+        const data = { ...createData };
+        delete (data as { jobId?: string | null }).jobId;
+        return data;
+      })(),
+    ],
+  ])("rejects malformed realtime creation responses missing %s", async (_field, data) => {
+    mockPrompt.mockResolvedValueOnce({
+      data: {
+        data,
+        status: "success",
+        message: "Agent prompt accepted",
+      },
+    });
+
+    await expect(
+      createTestClient().assistant.createRealtimeWorkflow({
+        instructions: "Monitor https://example.com for price changes",
+        notificationChannelIds: ["11111111-1111-4111-8111-111111111111"],
+      }),
+    ).rejects.toBeInstanceOf(KadoaSdkException);
+  });
+
+  test("rejects malformed realtime creation success envelopes", async () => {
+    mockPrompt.mockResolvedValueOnce({
+      data: { status: "success", message: "Agent prompt accepted" },
+    });
+
+    await expect(
+      createTestClient().assistant.createRealtimeWorkflow({
+        instructions: "Monitor https://example.com for price changes",
+        notificationChannelIds: ["11111111-1111-4111-8111-111111111111"],
+      }),
+    ).rejects.toBeInstanceOf(KadoaSdkException);
   });
 
   test("requests an identity-preserving workflow update", async () => {

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -317,10 +317,15 @@
                           },
                           "data": {
                             "type": "array",
+                            "nullable": true,
                             "description": "Current state of the data after the change",
                             "items": {
                               "type": "object"
                             }
+                          },
+                          "dataPending": {
+                            "type": "boolean",
+                            "description": "True when durable change data is still being stored; change events are emitted first so users see changes as fast as possible."
                           },
                           "differences": {
                             "type": "array",
@@ -507,10 +512,15 @@
                     },
                     "data": {
                       "type": "array",
+                      "nullable": true,
                       "description": "Current state of the data after the change",
                       "items": {
                         "type": "object"
                       }
+                    },
+                    "dataPending": {
+                      "type": "boolean",
+                      "description": "True when durable change data is still being stored; change events are emitted first so users see changes as fast as possible."
                     },
                     "differences": {
                       "type": "array",
@@ -975,6 +985,15 @@
               "default": "false"
             },
             "description": "When true, includes resolved issues in the response. Defaults to false."
+          },
+          {
+            "name": "workflowId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "When set, only returns issues attached to this workflow."
           }
         ],
         "responses": {
@@ -1371,6 +1390,44 @@
         }
       }
     },
+    "/v4/support/attachments": {
+      "post": {
+        "summary": "Upload support ticket attachments",
+        "description": "Uploads files to Linear's asset storage and returns their asset URLs for use in a subsequent issue creation. Multipart form data with a \"files\" field (max 10 files, 25MB each).\n",
+        "tags": [
+          "Support"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "files": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Uploaded files with Linear asset URLs"
+          }
+        }
+      }
+    },
     "/v4/support/issues/{issueId}": {
       "patch": {
         "summary": "Update issue priority and/or status",
@@ -1631,7 +1688,7 @@
     "/v4/workflows/bulk": {
       "post": {
         "summary": "Perform bulk operations on multiple workflows",
-        "description": "Execute actions on multiple workflows at once. Best-effort processing - each workflow is processed independently. The 'approve' action approves sample data for workflows in PREVIEW state.",
+        "description": "Execute actions on multiple workflows at once. Best-effort processing - each workflow is processed independently. The 'approve' action approves preview data for workflows in PREVIEW state.",
         "tags": [
           "Workflows"
         ],
@@ -3180,6 +3237,124 @@
         }
       }
     },
+    "/v4/workflows/{workflowId}/history/metrics": {
+      "get": {
+        "summary": "Get aggregated run success metrics for a workflow",
+        "description": "Per-day successful/failed run counts and the overall success rate over the requested window, aggregated over all runs (not paginated). Days are bucketed by the run's finish date in UTC.",
+        "tags": [
+          "Workflows"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workflowId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The unique identifier of the workflow"
+          },
+          {
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 90,
+              "default": 30
+            },
+            "description": "Number of calendar days (UTC) covered by the window, from midnight days-1 days ago through now"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Aggregated run metrics for the workflow",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "workflowId": {
+                      "type": "string",
+                      "description": "Unique identifier of the workflow"
+                    },
+                    "windowStart": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Inclusive start of the aggregation window"
+                    },
+                    "windowEnd": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Exclusive end of the aggregation window"
+                    },
+                    "totalRuns": {
+                      "type": "integer",
+                      "description": "Number of terminal (finished or failed) runs in the window"
+                    },
+                    "successfulRuns": {
+                      "type": "integer",
+                      "description": "Number of finished runs in the window"
+                    },
+                    "failedRuns": {
+                      "type": "integer",
+                      "description": "Number of failed runs in the window"
+                    },
+                    "successRatePercentage": {
+                      "type": "number",
+                      "nullable": true,
+                      "description": "successfulRuns / totalRuns as a percentage, null when the window has no terminal runs"
+                    },
+                    "daily": {
+                      "type": "array",
+                      "description": "Per-day buckets (UTC, by run finish date); days without terminal runs are omitted",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "UTC calendar day of the bucket"
+                          },
+                          "successfulRuns": {
+                            "type": "integer"
+                          },
+                          "failedRuns": {
+                            "type": "integer"
+                          },
+                          "uptimePercentage": {
+                            "type": "number",
+                            "description": "successfulRuns / (successfulRuns + failedRuns) for the day as a percentage"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid workflow ID or days parameter"
+          },
+          "401": {
+            "description": "Unauthorized access, either due to missing or invalid x-api-key"
+          },
+          "404": {
+            "description": "Workflow with the specified ID could not be found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/v4/workflows/{workflowId}/history": {
       "get": {
         "summary": "Get the workflow run history",
@@ -3613,7 +3788,7 @@
           {
             "name": "search",
             "in": "query",
-            "description": "Search term to filter workflows by name, URL, or workflow ID",
+            "description": "Search term to filter workflows by name or workflow ID",
             "required": false,
             "schema": {
               "type": "string"
@@ -3714,7 +3889,19 @@
           {
             "name": "tags",
             "in": "query",
-            "description": "Filter workflows by tags",
+            "description": "Filter workflows by tags. Accepts repeated params, comma-separated values, or a JSON array.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "statusFilters",
+            "in": "query",
+            "description": "Dashboard status filters. Accepts repeated params, comma-separated values, or a JSON array.",
             "required": false,
             "schema": {
               "type": "array",
@@ -3726,10 +3913,25 @@
           {
             "name": "userId",
             "in": "query",
-            "description": "Filter workflows by user ID (team members only)",
+            "description": "Filter workflows by one or more user IDs. Accepts repeated params, comma-separated values, or a JSON array.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "channelId",
+            "in": "query",
+            "description": "Filter workflows by one or more notification channel IDs. Accepts repeated params, comma-separated values, or a JSON array.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           {
@@ -3748,7 +3950,7 @@
           {
             "name": "updateInterval",
             "in": "query",
-            "description": "Filter workflows by update interval",
+            "description": "Filter workflows by update interval. REAL_TIME matches workflows that run in real time (independent of notifications).",
             "required": false,
             "schema": {
               "type": "string",
@@ -3756,7 +3958,8 @@
                 "HOURLY",
                 "DAILY",
                 "WEEKLY",
-                "MONTHLY"
+                "MONTHLY",
+                "REAL_TIME"
               ]
             }
           },
@@ -3771,6 +3974,18 @@
                 "RUN_ONCE",
                 "RECURRING"
               ]
+            }
+          },
+          {
+            "name": "templateId",
+            "in": "query",
+            "description": "Filter to workflows instantiated from one or more template IDs. Accepts repeated params, comma-separated values, or a JSON array.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           {
@@ -3902,6 +4117,12 @@
                             "type": "boolean",
                             "description": "Whether this workflow should be displayed as realtime"
                           },
+                          "lastDataChangedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true,
+                            "description": "Most recent persisted customer-visible data change for a real-time workflow"
+                          },
                           "tags": {
                             "type": "array",
                             "items": {
@@ -4017,28 +4238,17 @@
                               }
                             }
                           },
-                          "navigationMode": {
-                            "type": "string",
-                            "enum": [
-                              "single-page",
-                              "paginated-page",
-                              "page-and-detail",
-                              "agentic-navigation",
-                              "all-pages"
-                            ],
-                            "description": "Navigation mode for scraping. Determines how the scraper navigates through pages"
-                          },
                           "maxDepth": {
                             "type": "integer",
                             "minimum": 1,
                             "maximum": 200,
-                            "description": "Maximum crawl depth (default: 50, max: 200). Only used when navigationMode is 'all-pages'"
+                            "description": "Maximum crawl depth (default: 50, max: 200)."
                           },
                           "maxPages": {
                             "type": "integer",
                             "minimum": 1,
                             "maximum": 100000,
-                            "description": "Maximum pages to crawl (default: 10,000, max: 100,000). Only used when navigationMode is 'all-pages'"
+                            "description": "Maximum pages to crawl (default: 10,000, max: 100,000)."
                           },
                           "schema": {
                             "type": "array",
@@ -4662,10 +4872,321 @@
         }
       }
     },
+    "/v4/workflows/{workflowId}/quality-metrics": {
+      "get": {
+        "summary": "Get workflow quality metrics",
+        "description": "Returns the data quality metric results for a workflow run, plus the run's total data\nquality issue count.\n\nMetrics are only available once the run has finished, before that the endpoint returns\n`{ \"results\": null, \"issueCount\": null }`.\n\nEach metric result carries a `status`:\n- `OK`: the metric was computed, see `data` for it's details.\n- `PENDING`: the metric has not been computed yet.\n- `NOT_APPLICABLE`: the metric cannot be computed for this workflow, see `message`.\n- `ERROR`: the metric computation failed, see `message`.\n",
+        "tags": [
+          "Workflows"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workflowId",
+            "in": "path",
+            "required": true,
+            "description": "ID of the workflow to retrieve quality metrics for",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "jobId",
+            "in": "query",
+            "required": false,
+            "description": "ID of a specific run. Omit to use the latest run.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Quality metric results. `results` and `issueCount` are null until the run has finished.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "results",
+                    "issueCount"
+                  ],
+                  "properties": {
+                    "results": {
+                      "type": "object",
+                      "nullable": true,
+                      "description": "Metric results keyed by metric. Null until the run has finished.",
+                      "properties": {
+                        "COMPLETENESS": {
+                          "type": "object",
+                          "description": "Whether the extraction found as many rows as the source suggests.",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "enum": [
+                                "COMPLETENESS"
+                              ]
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "OK",
+                                "PENDING",
+                                "NOT_APPLICABLE",
+                                "ERROR"
+                              ]
+                            },
+                            "message": {
+                              "type": "string",
+                              "description": "Explanation, present when status is NOT_APPLICABLE or ERROR."
+                            },
+                            "data": {
+                              "type": "object",
+                              "description": "Metric details, present when status is OK.",
+                              "properties": {
+                                "score": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 100,
+                                  "deprecated": true,
+                                  "description": "Deprecated & scheduled for removal."
+                                },
+                                "actualRowCount": {
+                                  "type": "integer",
+                                  "description": "Number of rows the extraction produced."
+                                },
+                                "expectedRowCount": {
+                                  "type": "integer",
+                                  "description": "Number of rows the source suggests should exist."
+                                },
+                                "cappedByLimit": {
+                                  "type": "boolean",
+                                  "description": "True when the row count was capped by the workflow's extraction limit."
+                                },
+                                "signals": {
+                                  "type": "array",
+                                  "description": "Evidence used to derive the expected row count.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "totalCount": {
+                                        "type": "integer"
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      },
+                                      "sources": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "count": {
+                                              "type": "integer"
+                                            },
+                                            "xpath": {
+                                              "type": "string"
+                                            },
+                                            "regex": {
+                                              "type": "string"
+                                            },
+                                            "source": {
+                                              "type": "string"
+                                            },
+                                            "url": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "SCHEMA_VALIDATION": {
+                          "type": "object",
+                          "description": "Checks the dataset against the workflow's schema validation rules.",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "enum": [
+                                "SCHEMA_VALIDATION"
+                              ]
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "OK",
+                                "PENDING",
+                                "NOT_APPLICABLE",
+                                "ERROR"
+                              ]
+                            },
+                            "message": {
+                              "type": "string",
+                              "description": "Explanation, present when status is NOT_APPLICABLE or ERROR."
+                            },
+                            "data": {
+                              "type": "object",
+                              "description": "Metric details, present when status is OK.",
+                              "properties": {
+                                "score": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 100,
+                                  "deprecated": true,
+                                  "description": "Deprecated & scheduled for removal."
+                                },
+                                "ruleViolationCount": {
+                                  "type": "integer",
+                                  "description": "Number of violated rules."
+                                },
+                                "rowViolationCount": {
+                                  "type": "integer",
+                                  "description": "Number of rows affected by violations."
+                                },
+                                "columns": {
+                                  "type": "array",
+                                  "description": "Per-column validation results.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "score": {
+                                        "type": "number",
+                                        "deprecated": true,
+                                        "description": "Deprecated & scheduled for removal."
+                                      },
+                                      "rulesConfigured": {
+                                        "type": "boolean"
+                                      },
+                                      "violations": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "SEMANTIC_PLAUSIBILITY": {
+                          "type": "object",
+                          "description": "Flags values that do not fit with the rest of the dataset.",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "enum": [
+                                "SEMANTIC_PLAUSIBILITY"
+                              ]
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "OK",
+                                "PENDING",
+                                "NOT_APPLICABLE",
+                                "ERROR"
+                              ]
+                            },
+                            "message": {
+                              "type": "string",
+                              "description": "Explanation, present when status is NOT_APPLICABLE or ERROR."
+                            },
+                            "data": {
+                              "type": "object",
+                              "description": "Metric details, present when status is OK.",
+                              "properties": {
+                                "score": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 100,
+                                  "deprecated": true,
+                                  "description": "Deprecated & scheduled for removal."
+                                },
+                                "columns": {
+                                  "type": "array",
+                                  "description": "Per-column plausibility results.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "score": {
+                                        "type": "number",
+                                        "deprecated": true,
+                                        "description": "Deprecated & scheduled for removal."
+                                      },
+                                      "flaggedPercent": {
+                                        "type": "number"
+                                      },
+                                      "reasoning": {
+                                        "type": "string"
+                                      },
+                                      "flaggedExamples": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "issueCount": {
+                      "type": "integer",
+                      "nullable": true,
+                      "description": "Total number of data quality issues detected for the run. Null until the run has finished."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid workflow ID format"
+          },
+          "401": {
+            "description": "Unauthorized (invalid or missing API key or Bearer token)"
+          },
+          "404": {
+            "description": "Workflow not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/v4/workflows/{workflowId}/resume": {
       "put": {
-        "summary": "Resume a workflow",
-        "description": "Resumes/Activates a paused, preview, or error workflow.",
+        "summary": "Resume or unpause a workflow",
+        "description": "Unpauses a paused workflow, or resumes a preview/error workflow.",
         "tags": [
           "Workflows"
         ],
@@ -4696,7 +5217,9 @@
                     "message": {
                       "type": "string",
                       "enum": [
+                        "Workflow unpaused",
                         "Workflow resumed",
+                        "Workflow unpaused and sent for compliance review",
                         "Workflow resumed and sent for compliance review"
                       ]
                     }
@@ -4806,6 +5329,38 @@
           },
           "401": {
             "description": "x-api-key missing or not authorized"
+          },
+          "409": {
+            "description": "Workflow lifecycle conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string",
+                      "enum": [
+                        "WORKFLOW_NOT_FINALISED",
+                        "PREVIEW_AWAITS_CUSTOMER_CONFIRMATION"
+                      ]
+                    },
+                    "recoveryHint": {
+                      "type": "string"
+                    },
+                    "existingState": {
+                      "type": "string",
+                      "enum": [
+                        "DRAFT",
+                        "PREVIEW"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
           },
           "429": {
             "description": "Too many concurrent jobs",
@@ -5539,6 +6094,334 @@
         }
       }
     },
+    "/v5/agent": {
+      "post": {
+        "operationId": "v5AgentPrompt",
+        "summary": "Create or continue a public Agent session",
+        "description": "Creates a draft workflow-backed Assistant session. Explicit productType=realtime dispatches the Julie realtime lane after realtime notification settings are provisioned.",
+        "tags": [
+          "Agent"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentPromptRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Agent prompt accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentPromptResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or realtime notification settings"
+          },
+          "403": {
+            "description": "Authenticated user cannot create workflows for the active team"
+          },
+          "404": {
+            "description": "Template, Assistant session, or thread not found"
+          },
+          "409": {
+            "description": "Agent prompt conflicts with the requested context"
+          }
+        }
+      }
+    },
+    "/v5/agent/workflows/{workflowId}/assistant/messages": {
+      "post": {
+        "operationId": "v5AgentWorkflowAssistantMessage",
+        "summary": "Request an Assistant update to an existing workflow",
+        "description": "Bootstraps or reuses the workflow's customer Assistant session and enqueues update instructions without changing the workflow ID.",
+        "tags": [
+          "Agent"
+        ],
+        "parameters": [
+          {
+            "name": "workflowId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowAssistantMessageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Workflow Assistant update accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowAssistantMessageResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid workflow ID or request body"
+          },
+          "404": {
+            "description": "Workflow or Assistant session not found"
+          },
+          "409": {
+            "description": "Assistant session or thread conflict"
+          }
+        }
+      }
+    },
+    "/v5/agent/{sessionId}/pause-state": {
+      "get": {
+        "operationId": "v5AgentPauseState",
+        "summary": "Get durable Assistant pause and question state",
+        "tags": [
+          "Agent"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Assistant pause state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantPauseStateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found"
+          },
+          "409": {
+            "description": "Invalid session pause state"
+          },
+          "503": {
+            "description": "Assistant manager temporarily unavailable"
+          }
+        }
+      }
+    },
+    "/v5/agent/answer": {
+      "post": {
+        "operationId": "v5AgentAnswer",
+        "summary": "Answer a durable Assistant question",
+        "tags": [
+          "Agent"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssistantAnswerRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Answer accepted and session resume requested",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantAnswerResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "404": {
+            "description": "Session or question not found"
+          },
+          "409": {
+            "description": "Question has already resumed or cannot accept an answer"
+          }
+        }
+      }
+    },
+    "/v5/agent/{sessionId}/interrupt": {
+      "post": {
+        "operationId": "v5AgentInterrupt",
+        "summary": "Safely interrupt an active Assistant session",
+        "tags": [
+          "Agent"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Interrupt accepted or the session was already paused",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantControlResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found for the authenticated team"
+          },
+          "409": {
+            "description": "Session cannot be interrupted from its current state"
+          }
+        }
+      }
+    },
+    "/v5/agent/{sessionId}/resume": {
+      "post": {
+        "operationId": "v5AgentResume",
+        "summary": "Resume an inactive or interrupted Assistant session",
+        "description": "Resumes with the persona persisted on the session, preserving Lighthouse versus Julie behavior.",
+        "tags": [
+          "Agent"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resume accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantResumeResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found for the authenticated team"
+          },
+          "409": {
+            "description": "Session is already active or cannot be resumed"
+          }
+        }
+      }
+    },
+    "/v5/agent/{sessionId}/stop": {
+      "post": {
+        "operationId": "v5AgentStop",
+        "summary": "Stop an active Assistant session",
+        "tags": [
+          "Agent"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stop accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantControlResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found for the authenticated team"
+          },
+          "409": {
+            "description": "Session is not active"
+          }
+        }
+      }
+    },
+    "/v5/agent/data/{sessionId}/strategy": {
+      "get": {
+        "operationId": "v5AgentStrategy",
+        "summary": "Get the latest customer-safe Assistant extraction strategy",
+        "description": "Returns strategy null when the session exists but no build strategy is available yet.",
+        "tags": [
+          "Agent"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Latest extraction strategy, or null while unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantStrategyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found"
+          }
+        }
+      }
+    },
     "/v5/changes": {
       "get": {
         "summary": "Get all data changes (PostgreSQL)",
@@ -5652,10 +6535,15 @@
                           },
                           "data": {
                             "type": "array",
+                            "nullable": true,
                             "description": "Current state of the data after the change",
                             "items": {
                               "type": "object"
                             }
+                          },
+                          "dataPending": {
+                            "type": "boolean",
+                            "description": "True when durable change data is still being stored; change events are emitted first so users see changes as fast as possible."
                           },
                           "differences": {
                             "type": "array",
@@ -5826,10 +6714,15 @@
                     },
                     "data": {
                       "type": "array",
+                      "nullable": true,
                       "description": "Current state of the data after the change",
                       "items": {
                         "type": "object"
                       }
+                    },
+                    "dataPending": {
+                      "type": "boolean",
+                      "description": "True when durable change data is still being stored; change events are emitted first so users see changes as fast as possible."
                     },
                     "differences": {
                       "type": "array",
@@ -13539,6 +14432,974 @@
         ]
       }
     },
+    "/v4/scrape": {
+      "post": {
+        "description": "Fetch a URL through Kadoa. Defaults to smart routing (auto fetch mode and proxy), can return page content as markdown for LLM consumption, and offers a stealth proxy tier for sites that block bots.",
+        "summary": "Scrape a URL",
+        "tags": [
+          "Scrape"
+        ],
+        "parameters": [],
+        "requestBody": {
+          "description": "Body",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "method": {
+                    "default": "GET",
+                    "type": "string",
+                    "enum": [
+                      "GET",
+                      "POST",
+                      "PUT",
+                      "DELETE",
+                      "PATCH"
+                    ],
+                    "description": "HTTP method. Default: GET"
+                  },
+                  "headers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "Header name"
+                        },
+                        "value": {
+                          "type": "string",
+                          "description": "Header value"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "value"
+                      ],
+                      "description": "Custom HTTP header"
+                    },
+                    "description": "Custom HTTP headers to send with the request"
+                  },
+                  "body": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "additionalProperties": {
+                          "nullable": true
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "Request body as JSON object, or a legacy worker-specific string. Prefer rawBody when the upstream endpoint needs an exact text payload."
+                  },
+                  "rawBody": {
+                    "type": "string",
+                    "description": "Exact request body text to forward to the upstream URL. Use for endpoints that reject wrapper objects or require a specific JSON/form payload string."
+                  },
+                  "location": {
+                    "type": "object",
+                    "properties": {
+                      "country": {
+                        "type": "string",
+                        "minLength": 2,
+                        "maxLength": 2,
+                        "description": "ISO 3166-1 alpha-2 country code (e.g., 'US', 'GB', 'DE')"
+                      }
+                    },
+                    "description": "Geo-targeting for proxy selection"
+                  },
+                  "timeout": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 60000,
+                    "description": "Per-attempt timeout in milliseconds"
+                  },
+                  "overallTimeout": {
+                    "default": 300000,
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 300000,
+                    "description": "Wall-clock deadline for the complete scrape in milliseconds. Default and maximum: 300000"
+                  },
+                  "context": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "Context ID for session persistence. Use workflow ID for convenience. Created automatically if it does not exist."
+                      },
+                      "persist": {
+                        "type": "boolean",
+                        "description": "Save browser state (cookies, localStorage) after scrape. Default: false"
+                      }
+                    },
+                    "description": "Session context for cookie persistence"
+                  },
+                  "captureResponses": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "maxItems": 20,
+                    "description": "Substrings matched against network response URLs (browser workers only). The worker hooks every response the page makes and returns the body of each whose URL contains any of these substrings, in `capturedResponses`. Use this to read data that arrives via XHR/fetch and is NOT in the DOM — SPA dashboards (Tableau VizQL, Power BI) where values come back in a JSON/command response. Triggers a browser worker; pair with `browserActions` (clicks/waits) to drive the requests you want captured."
+                  },
+                  "waitUntil": {
+                    "type": "string",
+                    "enum": [
+                      "load",
+                      "domcontentloaded",
+                      "networkidle",
+                      "commit"
+                    ],
+                    "description": "Browser-worker navigation gate. Default (omitted) is `domcontentloaded` + a bounded best-effort networkidle settle, which returns content even on heavy pages that never go fully idle (ASP.NET, SignalR, ad/telemetry-heavy). Set `networkidle` to block the whole navigation on full idle (old behavior — only when the page reliably goes idle and you need every lazy request). No-op for non-browser workers."
+                  },
+                  "settleMs": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Browser-worker cap (ms) for the best-effort networkidle settle after `domcontentloaded`. Default 15000. Raise for slow client-rendered pages that need more time for lazy content; lower to return faster. Ignored when `waitUntil: networkidle` and for non-browser workers."
+                  },
+                  "device": {
+                    "type": "string",
+                    "description": "Device to emulate, by descriptor name (e.g. 'iPad', 'iPhone 13'). Honored by workers that support device emulation; ignored by the rest. Some sites only serve content for a given device profile."
+                  },
+                  "fetchMode": {
+                    "default": "auto",
+                    "type": "string",
+                    "enum": [
+                      "http",
+                      "browser",
+                      "auto"
+                    ],
+                    "description": "Fetch mode: http for fast requests, browser for JavaScript rendering and browser actions, or auto for smart routing that starts cheap and escalates when blocked. Default: auto"
+                  },
+                  "proxy": {
+                    "default": "auto",
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "dc",
+                      "isp",
+                      "residential",
+                      "stealth"
+                    ],
+                    "description": "Proxy tier: auto (smart selection), dc (datacenter), isp, residential, or stealth to route through the anti-bot providers for sites that block bots. Stealth providers use their own egress and pricing. Default: auto"
+                  },
+                  "format": {
+                    "default": "html",
+                    "type": "string",
+                    "enum": [
+                      "html",
+                      "markdown"
+                    ],
+                    "description": "Content format for HTML pages. markdown converts the page to markdown with navigation, header, and footer stripped — the compact shape to feed an LLM. Non-HTML responses (JSON, binary) and HTML pages over 2 MB are returned unchanged; check the response contentType to see which format was applied. Default: html"
+                  },
+                  "browserActions": {
+                    "type": "array",
+                    "items": {
+                      "discriminator": {
+                        "propertyName": "type"
+                      },
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "click"
+                              ],
+                              "description": "Action type"
+                            },
+                            "selector": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "xpath",
+                                    "css",
+                                    "text"
+                                  ],
+                                  "description": "Selector type"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "Selector value (e.g., '#submit-btn' for CSS, '//button[@type=\"submit\"]' for XPath)"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "value"
+                              ],
+                              "description": "Element to click"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "selector"
+                          ],
+                          "title": "click",
+                          "description": "Click an element on the page"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "input"
+                              ],
+                              "description": "Action type"
+                            },
+                            "selector": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "xpath",
+                                    "css",
+                                    "text"
+                                  ],
+                                  "description": "Selector type"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "Selector value (e.g., '#submit-btn' for CSS, '//button[@type=\"submit\"]' for XPath)"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "value"
+                              ],
+                              "description": "Input element to type into"
+                            },
+                            "value": {
+                              "type": "string",
+                              "description": "Text to type into the element"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "selector",
+                            "value"
+                          ],
+                          "title": "input",
+                          "description": "Type text into an input element"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "scroll"
+                              ],
+                              "description": "Action type"
+                            },
+                            "x": {
+                              "type": "number",
+                              "description": "Horizontal scroll amount in pixels"
+                            },
+                            "y": {
+                              "type": "number",
+                              "description": "Vertical scroll amount in pixels"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "y"
+                          ],
+                          "title": "scroll",
+                          "description": "Scroll by a specific number of pixels"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "scroll_to_bottom"
+                              ],
+                              "description": "Action type"
+                            },
+                            "timeout_s": {
+                              "type": "number",
+                              "minimum": 1,
+                              "maximum": 300,
+                              "description": "Maximum time to scroll in seconds (default: 30, maximum: 300)"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "title": "scroll_to_bottom",
+                          "description": "Scroll to the bottom of the page (useful for infinite scroll)"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "wait"
+                              ],
+                              "description": "Action type"
+                            },
+                            "wait_time_s": {
+                              "type": "number",
+                              "minimum": 1,
+                              "maximum": 300,
+                              "description": "Duration to wait in seconds (maximum: 300)"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "wait_time_s"
+                          ],
+                          "title": "wait",
+                          "description": "Wait for a specified duration"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "screenshot"
+                              ],
+                              "description": "Action type"
+                            },
+                            "full_page": {
+                              "type": "boolean",
+                              "description": "Capture the full page (true) or just the viewport (false)"
+                            },
+                            "format": {
+                              "default": "jpg",
+                              "type": "string",
+                              "enum": [
+                                "jpg",
+                                "png",
+                                "webp"
+                              ],
+                              "description": "Output image format. Default: jpg"
+                            },
+                            "quality": {
+                              "default": 20,
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 100,
+                              "description": "Compression quality (1-100). Only applies to jpg and webp. Ignored for png. Default: 20"
+                            },
+                            "width": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "description": "Resize to this width in pixels (height scales proportionally). No upscaling."
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "title": "screenshot",
+                          "description": "Capture a screenshot of the page"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "evaluate_js"
+                              ],
+                              "description": "Action type"
+                            },
+                            "script": {
+                              "type": "string",
+                              "description": "JavaScript code to execute in the page context"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "script"
+                          ],
+                          "title": "evaluate_js",
+                          "description": "Execute JavaScript in the browser context"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "wait_for_element"
+                              ],
+                              "description": "Action type"
+                            },
+                            "selector": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "xpath",
+                                    "css",
+                                    "text"
+                                  ],
+                                  "description": "Selector type"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "Selector value (e.g., '#submit-btn' for CSS, '//button[@type=\"submit\"]' for XPath)"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "value"
+                              ],
+                              "description": "Element to wait for"
+                            },
+                            "timeout_s": {
+                              "type": "number",
+                              "minimum": 1,
+                              "maximum": 300,
+                              "description": "Maximum time to wait in seconds (default: 10, maximum: 300)"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "selector"
+                          ],
+                          "title": "wait_for_element",
+                          "description": "Wait for an element to appear on the page"
+                        }
+                      ],
+                      "description": "Browser action to perform on the page"
+                    },
+                    "maxItems": 50
+                  }
+                },
+                "required": [
+                  "url"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Scrape response with content and execution metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Whether the scrape succeeded"
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "description": "MIME type of the response (e.g., text/html, application/json, image/png)"
+                    },
+                    "content": {
+                      "type": "string",
+                      "description": "Response content (raw text for html/json, base64 for binary)"
+                    },
+                    "isBase64": {
+                      "default": false,
+                      "type": "boolean",
+                      "description": "Whether content is base64-encoded (true for binary content types like PDFs, images)"
+                    },
+                    "screenshots": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "URLs of captured screenshots"
+                    },
+                    "jsResults": {
+                      "type": "array",
+                      "items": {
+                        "nullable": true
+                      },
+                      "description": "Results of evaluate_js actions, in order of execution. Each entry is the JSON-serializable return value, or {error: string} if the script threw."
+                    },
+                    "capturedResponses": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string",
+                            "description": "Full URL of the captured response"
+                          },
+                          "status": {
+                            "type": "number",
+                            "description": "HTTP status code of the captured response"
+                          },
+                          "body": {
+                            "type": "string",
+                            "description": "Response body as text"
+                          }
+                        },
+                        "required": [
+                          "url",
+                          "status",
+                          "body"
+                        ]
+                      },
+                      "description": "Bodies of network responses whose URL matched a `captureResponses` substring, in arrival order. Present only when `captureResponses` was set and at least one response matched."
+                    },
+                    "statusCode": {
+                      "type": "number",
+                      "description": "HTTP status code from the response"
+                    },
+                    "headers": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Response headers as key-value pairs"
+                    },
+                    "cookies": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "Cookie name"
+                          },
+                          "value": {
+                            "type": "string",
+                            "description": "Cookie value"
+                          },
+                          "domain": {
+                            "type": "string",
+                            "description": "Cookie domain"
+                          },
+                          "path": {
+                            "type": "string",
+                            "description": "Cookie path"
+                          },
+                          "expires": {
+                            "type": "number",
+                            "description": "Expiration timestamp (Unix epoch)"
+                          },
+                          "httpOnly": {
+                            "type": "boolean",
+                            "description": "HttpOnly flag"
+                          },
+                          "secure": {
+                            "type": "boolean",
+                            "description": "Secure flag"
+                          },
+                          "sameSite": {
+                            "type": "string",
+                            "enum": [
+                              "Strict",
+                              "Lax",
+                              "None"
+                            ],
+                            "description": "SameSite attribute"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "description": "HTTP cookie from the response"
+                      },
+                      "description": "Cookies set by the response"
+                    },
+                    "finalUrl": {
+                      "type": "string",
+                      "description": "Final URL after any redirects"
+                    },
+                    "execution": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Opaque request identifier for correlating scraper API and worker lifecycle diagnostics"
+                        },
+                        "totalDurationMs": {
+                          "type": "number",
+                          "description": "Total time including all retries in milliseconds"
+                        },
+                        "contextId": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Context ID used or created, if context feature was used"
+                        },
+                        "contextPersisted": {
+                          "type": "boolean",
+                          "description": "Whether browser state was saved back to context"
+                        },
+                        "attempts": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "worker": {
+                                "type": "string",
+                                "enum": [
+                                  "http",
+                                  "browser",
+                                  "stealth-http",
+                                  "stealth-browser"
+                                ],
+                                "description": "Worker capability used for this attempt"
+                              },
+                              "proxy": {
+                                "type": "string",
+                                "enum": [
+                                  "dc",
+                                  "isp",
+                                  "residential"
+                                ],
+                                "description": "Proxy type: datacenter, ISP, or residential",
+                                "nullable": true
+                              },
+                              "location": {
+                                "type": "object",
+                                "properties": {
+                                  "country": {
+                                    "type": "string",
+                                    "minLength": 2,
+                                    "maxLength": 2,
+                                    "description": "ISO 3166-1 alpha-2 country code (e.g., 'US', 'GB', 'DE')"
+                                  }
+                                },
+                                "description": "Location used for geo-targeting, or null",
+                                "nullable": true
+                              },
+                              "startedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "ISO 8601 timestamp when attempt started"
+                              },
+                              "endedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "ISO 8601 timestamp when attempt ended"
+                              },
+                              "durationMs": {
+                                "type": "number",
+                                "description": "Attempt duration in milliseconds"
+                              },
+                              "success": {
+                                "type": "boolean",
+                                "description": "Whether this attempt succeeded"
+                              },
+                              "error": {
+                                "type": "object",
+                                "properties": {
+                                  "code": {
+                                    "type": "string",
+                                    "enum": [
+                                      "BOT_DETECTED",
+                                      "ACCESS_DENIED",
+                                      "TIMEOUT",
+                                      "JS_REQUIRED",
+                                      "KYC_BLOCKED",
+                                      "MAX_RETRIES_EXCEEDED",
+                                      "NETWORK_ERROR",
+                                      "DEADLINE_EXCEEDED"
+                                    ],
+                                    "description": "Error code"
+                                  },
+                                  "message": {
+                                    "type": "string",
+                                    "description": "Human-readable error message"
+                                  }
+                                },
+                                "required": [
+                                  "code",
+                                  "message"
+                                ],
+                                "description": "Error details if attempt failed"
+                              }
+                            },
+                            "required": [
+                              "worker",
+                              "proxy",
+                              "location",
+                              "startedAt",
+                              "endedAt",
+                              "durationMs",
+                              "success"
+                            ],
+                            "description": "Details of a single scrape attempt"
+                          }
+                        }
+                      },
+                      "required": [
+                        "totalDurationMs",
+                        "attempts"
+                      ],
+                      "description": "Execution metadata including timing and retry information"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "enum": [
+                            "BOT_DETECTED",
+                            "ACCESS_DENIED",
+                            "TIMEOUT",
+                            "JS_REQUIRED",
+                            "KYC_BLOCKED",
+                            "MAX_RETRIES_EXCEEDED",
+                            "NETWORK_ERROR",
+                            "DEADLINE_EXCEEDED"
+                          ],
+                          "description": "Error code"
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable error message"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "description": "Error details when success is false"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "execution"
+                  ],
+                  "description": "Scrape response with content and execution metadata"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "429",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "502",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "504",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
     "/v4/templates/": {
       "get": {
         "description": "List all active templates for the authenticated user's team",
@@ -14135,6 +15996,194 @@
           },
           "404": {
             "description": "404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "description": "Indicates an error occurred"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    },
+                    "details": {
+                      "nullable": true,
+                      "description": "Additional error details (e.g., validation errors)"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "description": "Indicates an error occurred"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    },
+                    "details": {
+                      "nullable": true,
+                      "description": "Additional error details (e.g., validation errors)"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v4/templates/{templateId}/duplicate": {
+      "post": {
+        "description": "Create an independent copy of a template from its latest published version as a single new version 1, including prompt, schema, validation rules, notifications, and frequency. The copy has no linked workflows. Defaults the name to the source name plus a collision-safe \"(Copy)\" suffix.",
+        "summary": "Duplicate template",
+        "tags": [
+          "Templates"
+        ],
+        "parameters": [
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Template ID"
+          }
+        ],
+        "requestBody": {
+          "description": "Body",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DuplicateTemplateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateCreatedResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "description": "Indicates an error occurred"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    },
+                    "details": {
+                      "nullable": true,
+                      "description": "Additional error details (e.g., validation errors)"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "description": "Indicates an error occurred"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    },
+                    "details": {
+                      "nullable": true,
+                      "description": "Additional error details (e.g., validation errors)"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "description": "Indicates an error occurred"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    },
+                    "details": {
+                      "nullable": true,
+                      "description": "Additional error details (e.g., validation errors)"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "409",
             "content": {
               "application/json": {
                 "schema": {
@@ -16198,6 +18247,107 @@
         ]
       }
     },
+    "/v4/me/features": {
+      "get": {
+        "description": "Return the capabilities enabled for the authenticated team. Clients (such as the Kadoa MCP) use this to decide which tools to expose.",
+        "summary": "Get enabled capabilities",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "features": {
+                      "type": "object",
+                      "properties": {
+                        "scrape": {
+                          "type": "boolean",
+                          "description": "Whether this team may call POST /v4/scrape (the Scrape API)."
+                        }
+                      },
+                      "required": [
+                        "scrape"
+                      ],
+                      "description": "Capabilities enabled for the authenticated team."
+                    }
+                  },
+                  "required": [
+                    "features"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "description": "Indicates an error occurred"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    },
+                    "details": {
+                      "nullable": true,
+                      "description": "Additional error details (e.g., validation errors)"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "500",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "boolean",
+                      "description": "Indicates an error occurred"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    },
+                    "details": {
+                      "nullable": true,
+                      "description": "Additional error details (e.g., validation errors)"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
     "/v4/variables/": {
       "post": {
         "description": "Create a new key-value variable. Keys must be unique within the team/user scope. Variables can be referenced in workflow prompts using @variableKey syntax.",
@@ -16992,1342 +19142,6 @@
           }
         ]
       }
-    },
-    "/v4/scrape": {
-      "post": {
-        "description": "Fetch a URL through Kadoa. Defaults to smart routing (auto fetch mode and proxy), can return page content as markdown for LLM consumption, and offers a stealth proxy tier for sites that block bots.",
-        "summary": "Scrape a URL",
-        "tags": [
-          "Scrape"
-        ],
-        "parameters": [],
-        "requestBody": {
-          "description": "Body",
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "url": {
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "method": {
-                    "default": "GET",
-                    "type": "string",
-                    "enum": [
-                      "GET",
-                      "POST",
-                      "PUT",
-                      "DELETE",
-                      "PATCH"
-                    ],
-                    "description": "HTTP method. Default: GET"
-                  },
-                  "headers": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "key": {
-                          "type": "string",
-                          "description": "Header name"
-                        },
-                        "value": {
-                          "type": "string",
-                          "description": "Header value"
-                        }
-                      },
-                      "required": [
-                        "key",
-                        "value"
-                      ],
-                      "description": "Custom HTTP header"
-                    },
-                    "description": "Custom HTTP headers to send with the request"
-                  },
-                  "body": {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "additionalProperties": {
-                          "nullable": true
-                        }
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ],
-                    "description": "Request body as JSON object, or a legacy worker-specific string. Prefer rawBody when the upstream endpoint needs an exact text payload."
-                  },
-                  "rawBody": {
-                    "type": "string",
-                    "description": "Exact request body text to forward to the upstream URL. Use for endpoints that reject wrapper objects or require a specific JSON/form payload string."
-                  },
-                  "location": {
-                    "type": "object",
-                    "properties": {
-                      "country": {
-                        "type": "string",
-                        "minLength": 2,
-                        "maxLength": 2,
-                        "description": "ISO 3166-1 alpha-2 country code (e.g., 'US', 'GB', 'DE')"
-                      }
-                    },
-                    "description": "Geo-targeting for proxy selection"
-                  },
-                  "timeout": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 60000,
-                    "description": "Per-attempt timeout in milliseconds"
-                  },
-                  "context": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "description": "Context ID for session persistence. Use workflow ID for convenience. Created automatically if it does not exist."
-                      },
-                      "persist": {
-                        "type": "boolean",
-                        "description": "Save browser state (cookies, localStorage) after scrape. Default: false"
-                      }
-                    },
-                    "description": "Session context for cookie persistence"
-                  },
-                  "captureResponses": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "minLength": 1
-                    },
-                    "maxItems": 20,
-                    "description": "Substrings matched against network response URLs (browser workers only). The worker hooks every response the page makes and returns the body of each whose URL contains any of these substrings, in `capturedResponses`. Use this to read data that arrives via XHR/fetch and is NOT in the DOM — SPA dashboards (Tableau VizQL, Power BI) where values come back in a JSON/command response. Triggers a browser worker; pair with `browserActions` (clicks/waits) to drive the requests you want captured."
-                  },
-                  "waitUntil": {
-                    "type": "string",
-                    "enum": [
-                      "load",
-                      "domcontentloaded",
-                      "networkidle",
-                      "commit"
-                    ],
-                    "description": "Browser-worker navigation gate. Default (omitted) is `domcontentloaded` + a bounded best-effort networkidle settle, which returns content even on heavy pages that never go fully idle (ASP.NET, SignalR, ad/telemetry-heavy). Set `networkidle` to block the whole navigation on full idle (old behavior — only when the page reliably goes idle and you need every lazy request). No-op for non-browser workers."
-                  },
-                  "settleMs": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "description": "Browser-worker cap (ms) for the best-effort networkidle settle after `domcontentloaded`. Default 15000. Raise for slow client-rendered pages that need more time for lazy content; lower to return faster. Ignored when `waitUntil: networkidle` and for non-browser workers."
-                  },
-                  "device": {
-                    "type": "string",
-                    "description": "Device to emulate, by descriptor name (e.g. 'iPad', 'iPhone 13'). Honored by workers that support device emulation; ignored by the rest. Some sites only serve content for a given device profile."
-                  },
-                  "fetchMode": {
-                    "default": "auto",
-                    "type": "string",
-                    "enum": [
-                      "http",
-                      "browser",
-                      "auto"
-                    ],
-                    "description": "Fetch mode: http for fast requests, browser for JavaScript rendering and browser actions, or auto for smart routing that starts cheap and escalates when blocked. Default: auto"
-                  },
-                  "proxy": {
-                    "default": "auto",
-                    "type": "string",
-                    "enum": [
-                      "auto",
-                      "dc",
-                      "isp",
-                      "residential",
-                      "stealth"
-                    ],
-                    "description": "Proxy tier: auto (smart selection), dc (datacenter), isp, residential, or stealth to route through the anti-bot providers for sites that block bots. Stealth providers use their own egress and pricing. Default: auto"
-                  },
-                  "format": {
-                    "default": "html",
-                    "type": "string",
-                    "enum": [
-                      "html",
-                      "markdown"
-                    ],
-                    "description": "Content format for HTML pages. markdown converts the page to markdown with navigation, header, and footer stripped — the compact shape to feed an LLM. Non-HTML responses (JSON, binary) and HTML pages over 2 MB are returned unchanged; check the response contentType to see which format was applied. Default: html"
-                  },
-                  "browserActions": {
-                    "type": "array",
-                    "items": {
-                      "discriminator": {
-                        "propertyName": "type"
-                      },
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "click"
-                              ],
-                              "description": "Action type"
-                            },
-                            "selector": {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "enum": [
-                                    "xpath",
-                                    "css",
-                                    "text"
-                                  ],
-                                  "description": "Selector type"
-                                },
-                                "value": {
-                                  "type": "string",
-                                  "description": "Selector value (e.g., '#submit-btn' for CSS, '//button[@type=\"submit\"]' for XPath)"
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
-                              "description": "Element to click"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "selector"
-                          ],
-                          "title": "click",
-                          "description": "Click an element on the page"
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "input"
-                              ],
-                              "description": "Action type"
-                            },
-                            "selector": {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "enum": [
-                                    "xpath",
-                                    "css",
-                                    "text"
-                                  ],
-                                  "description": "Selector type"
-                                },
-                                "value": {
-                                  "type": "string",
-                                  "description": "Selector value (e.g., '#submit-btn' for CSS, '//button[@type=\"submit\"]' for XPath)"
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
-                              "description": "Input element to type into"
-                            },
-                            "value": {
-                              "type": "string",
-                              "description": "Text to type into the element"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "selector",
-                            "value"
-                          ],
-                          "title": "input",
-                          "description": "Type text into an input element"
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "scroll"
-                              ],
-                              "description": "Action type"
-                            },
-                            "x": {
-                              "type": "number",
-                              "description": "Horizontal scroll amount in pixels"
-                            },
-                            "y": {
-                              "type": "number",
-                              "description": "Vertical scroll amount in pixels"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "y"
-                          ],
-                          "title": "scroll",
-                          "description": "Scroll by a specific number of pixels"
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "scroll_to_bottom"
-                              ],
-                              "description": "Action type"
-                            },
-                            "timeout_s": {
-                              "type": "number",
-                              "description": "Maximum time to scroll in seconds (default: 30)"
-                            }
-                          },
-                          "required": [
-                            "type"
-                          ],
-                          "title": "scroll_to_bottom",
-                          "description": "Scroll to the bottom of the page (useful for infinite scroll)"
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "wait"
-                              ],
-                              "description": "Action type"
-                            },
-                            "wait_time_s": {
-                              "type": "number",
-                              "description": "Duration to wait in seconds"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "wait_time_s"
-                          ],
-                          "title": "wait",
-                          "description": "Wait for a specified duration"
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "screenshot"
-                              ],
-                              "description": "Action type"
-                            },
-                            "full_page": {
-                              "type": "boolean",
-                              "description": "Capture the full page (true) or just the viewport (false)"
-                            },
-                            "format": {
-                              "default": "jpg",
-                              "type": "string",
-                              "enum": [
-                                "jpg",
-                                "png",
-                                "webp"
-                              ],
-                              "description": "Output image format. Default: jpg"
-                            },
-                            "quality": {
-                              "default": 20,
-                              "type": "integer",
-                              "minimum": 1,
-                              "maximum": 100,
-                              "description": "Compression quality (1-100). Only applies to jpg and webp. Ignored for png. Default: 20"
-                            },
-                            "width": {
-                              "type": "integer",
-                              "minimum": 1,
-                              "description": "Resize to this width in pixels (height scales proportionally). No upscaling."
-                            }
-                          },
-                          "required": [
-                            "type"
-                          ],
-                          "title": "screenshot",
-                          "description": "Capture a screenshot of the page"
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "evaluate_js"
-                              ],
-                              "description": "Action type"
-                            },
-                            "script": {
-                              "type": "string",
-                              "description": "JavaScript code to execute in the page context"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "script"
-                          ],
-                          "title": "evaluate_js",
-                          "description": "Execute JavaScript in the browser context"
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "enum": [
-                                "wait_for_element"
-                              ],
-                              "description": "Action type"
-                            },
-                            "selector": {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "enum": [
-                                    "xpath",
-                                    "css",
-                                    "text"
-                                  ],
-                                  "description": "Selector type"
-                                },
-                                "value": {
-                                  "type": "string",
-                                  "description": "Selector value (e.g., '#submit-btn' for CSS, '//button[@type=\"submit\"]' for XPath)"
-                                }
-                              },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
-                              "description": "Element to wait for"
-                            },
-                            "timeout_s": {
-                              "type": "number",
-                              "description": "Maximum time to wait in seconds (default: 10)"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "selector"
-                          ],
-                          "title": "wait_for_element",
-                          "description": "Wait for an element to appear on the page"
-                        }
-                      ],
-                      "description": "Browser action to perform on the page"
-                    },
-                    "maxItems": 50
-                  }
-                },
-                "required": [
-                  "url"
-                ],
-                "additionalProperties": false
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Scrape response with content and execution metadata",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "description": "Whether the scrape succeeded"
-                    },
-                    "contentType": {
-                      "type": "string",
-                      "description": "MIME type of the response (e.g., text/html, application/json, image/png)"
-                    },
-                    "content": {
-                      "type": "string",
-                      "description": "Response content (raw text for html/json, base64 for binary)"
-                    },
-                    "isBase64": {
-                      "default": false,
-                      "type": "boolean",
-                      "description": "Whether content is base64-encoded (true for binary content types like PDFs, images)"
-                    },
-                    "screenshots": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      },
-                      "description": "URLs of captured screenshots"
-                    },
-                    "jsResults": {
-                      "type": "array",
-                      "items": {
-                        "nullable": true
-                      },
-                      "description": "Results of evaluate_js actions, in order of execution. Each entry is the JSON-serializable return value, or {error: string} if the script threw."
-                    },
-                    "capturedResponses": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "url": {
-                            "type": "string",
-                            "description": "Full URL of the captured response"
-                          },
-                          "status": {
-                            "type": "number",
-                            "description": "HTTP status code of the captured response"
-                          },
-                          "body": {
-                            "type": "string",
-                            "description": "Response body as text"
-                          }
-                        },
-                        "required": [
-                          "url",
-                          "status",
-                          "body"
-                        ]
-                      },
-                      "description": "Bodies of network responses whose URL matched a `captureResponses` substring, in arrival order. Present only when `captureResponses` was set and at least one response matched."
-                    },
-                    "statusCode": {
-                      "type": "number",
-                      "description": "HTTP status code from the response"
-                    },
-                    "headers": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "string"
-                      },
-                      "description": "Response headers as key-value pairs"
-                    },
-                    "cookies": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "description": "Cookie name"
-                          },
-                          "value": {
-                            "type": "string",
-                            "description": "Cookie value"
-                          },
-                          "domain": {
-                            "type": "string",
-                            "description": "Cookie domain"
-                          },
-                          "path": {
-                            "type": "string",
-                            "description": "Cookie path"
-                          },
-                          "expires": {
-                            "type": "number",
-                            "description": "Expiration timestamp (Unix epoch)"
-                          },
-                          "httpOnly": {
-                            "type": "boolean",
-                            "description": "HttpOnly flag"
-                          },
-                          "secure": {
-                            "type": "boolean",
-                            "description": "Secure flag"
-                          },
-                          "sameSite": {
-                            "type": "string",
-                            "enum": [
-                              "Strict",
-                              "Lax",
-                              "None"
-                            ],
-                            "description": "SameSite attribute"
-                          }
-                        },
-                        "required": [
-                          "name",
-                          "value"
-                        ],
-                        "description": "HTTP cookie from the response"
-                      },
-                      "description": "Cookies set by the response"
-                    },
-                    "finalUrl": {
-                      "type": "string",
-                      "description": "Final URL after any redirects"
-                    },
-                    "execution": {
-                      "type": "object",
-                      "properties": {
-                        "requestId": {
-                          "type": "string",
-                          "format": "uuid",
-                          "description": "Opaque request identifier for correlating scraper API and worker lifecycle diagnostics"
-                        },
-                        "totalDurationMs": {
-                          "type": "number",
-                          "description": "Total time including all retries in milliseconds"
-                        },
-                        "contextId": {
-                          "type": "string",
-                          "nullable": true,
-                          "description": "Context ID used or created, if context feature was used"
-                        },
-                        "contextPersisted": {
-                          "type": "boolean",
-                          "description": "Whether browser state was saved back to context"
-                        },
-                        "attempts": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "worker": {
-                                "type": "string",
-                                "enum": [
-                                  "http",
-                                  "browser",
-                                  "stealth-http",
-                                  "stealth-browser"
-                                ],
-                                "description": "Worker capability used for this attempt"
-                              },
-                              "proxy": {
-                                "type": "string",
-                                "enum": [
-                                  "dc",
-                                  "isp",
-                                  "residential"
-                                ],
-                                "description": "Proxy type: datacenter, ISP, or residential",
-                                "nullable": true
-                              },
-                              "location": {
-                                "type": "object",
-                                "properties": {
-                                  "country": {
-                                    "type": "string",
-                                    "minLength": 2,
-                                    "maxLength": 2,
-                                    "description": "ISO 3166-1 alpha-2 country code (e.g., 'US', 'GB', 'DE')"
-                                  }
-                                },
-                                "description": "Location used for geo-targeting, or null",
-                                "nullable": true
-                              },
-                              "startedAt": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "ISO 8601 timestamp when attempt started"
-                              },
-                              "endedAt": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "ISO 8601 timestamp when attempt ended"
-                              },
-                              "durationMs": {
-                                "type": "number",
-                                "description": "Attempt duration in milliseconds"
-                              },
-                              "success": {
-                                "type": "boolean",
-                                "description": "Whether this attempt succeeded"
-                              },
-                              "error": {
-                                "type": "object",
-                                "properties": {
-                                  "code": {
-                                    "type": "string",
-                                    "enum": [
-                                      "BOT_DETECTED",
-                                      "TIMEOUT",
-                                      "JS_REQUIRED",
-                                      "KYC_BLOCKED",
-                                      "MAX_RETRIES_EXCEEDED",
-                                      "NETWORK_ERROR"
-                                    ],
-                                    "description": "Error code"
-                                  },
-                                  "message": {
-                                    "type": "string",
-                                    "description": "Human-readable error message"
-                                  }
-                                },
-                                "required": [
-                                  "code",
-                                  "message"
-                                ],
-                                "description": "Error details if attempt failed"
-                              }
-                            },
-                            "required": [
-                              "worker",
-                              "proxy",
-                              "location",
-                              "startedAt",
-                              "endedAt",
-                              "durationMs",
-                              "success"
-                            ],
-                            "description": "Details of a single scrape attempt"
-                          }
-                        }
-                      },
-                      "required": [
-                        "totalDurationMs",
-                        "attempts"
-                      ],
-                      "description": "Execution metadata including timing and retry information"
-                    },
-                    "error": {
-                      "type": "object",
-                      "properties": {
-                        "code": {
-                          "type": "string",
-                          "enum": [
-                            "BOT_DETECTED",
-                            "TIMEOUT",
-                            "JS_REQUIRED",
-                            "KYC_BLOCKED",
-                            "MAX_RETRIES_EXCEEDED",
-                            "NETWORK_ERROR"
-                          ],
-                          "description": "Error code"
-                        },
-                        "message": {
-                          "type": "string",
-                          "description": "Human-readable error message"
-                        }
-                      },
-                      "required": [
-                        "code",
-                        "message"
-                      ],
-                      "description": "Error details when success is false"
-                    }
-                  },
-                  "required": [
-                    "success",
-                    "execution"
-                  ],
-                  "description": "Scrape response with content and execution metadata"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "400",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "message": {
-                      "type": "string"
-                    },
-                    "details": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      }
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "401",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "403",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "message": {
-                      "type": "string"
-                    },
-                    "details": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      }
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
-                  ]
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "429",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "message": {
-                      "type": "string"
-                    },
-                    "details": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      }
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "500",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "message": {
-                      "type": "string"
-                    },
-                    "details": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      }
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
-                  ]
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "502",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "message": {
-                      "type": "string"
-                    },
-                    "details": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      }
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
-                  ]
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "504",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "message": {
-                      "type": "string"
-                    },
-                    "details": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "nullable": true
-                      }
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
-                  ]
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ]
-      }
-    },
-    "/v4/me/features": {
-      "get": {
-        "description": "Return the capabilities enabled for the authenticated team. Clients (such as the Kadoa MCP) use this to decide which tools to expose.",
-        "summary": "Get enabled capabilities",
-        "tags": [
-          "Me"
-        ],
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "features": {
-                      "type": "object",
-                      "properties": {
-                        "scrape": {
-                          "type": "boolean",
-                          "description": "Whether this team may call POST /v4/scrape (the Scrape API)."
-                        }
-                      },
-                      "required": [
-                        "scrape"
-                      ],
-                      "description": "Capabilities enabled for the authenticated team."
-                    }
-                  },
-                  "required": [
-                    "features"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "401",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "boolean",
-                      "description": "Indicates an error occurred"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "Error message"
-                    },
-                    "details": {
-                      "nullable": true,
-                      "description": "Additional error details (e.g., validation errors)"
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "500",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "boolean",
-                      "description": "Indicates an error occurred"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "Error message"
-                    },
-                    "details": {
-                      "nullable": true,
-                      "description": "Additional error details (e.g., validation errors)"
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
-                  ]
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ]
-      }
-    },
-    "/v5/agent/workflows/{workflowId}/assistant/messages": {
-      "post": {
-        "operationId": "v5AgentWorkflowAssistantMessage",
-        "summary": "Request an Assistant update to an existing workflow",
-        "description": "Bootstraps or reuses the workflow's customer Assistant session and enqueues update instructions without changing the workflow ID.",
-        "tags": [
-          "Agent"
-        ],
-        "parameters": [
-          {
-            "name": "workflowId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkflowAssistantMessageRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "202": {
-            "description": "Workflow Assistant update accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowAssistantMessageResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid workflow ID or request body"
-          },
-          "404": {
-            "description": "Workflow or Assistant session not found"
-          },
-          "409": {
-            "description": "Assistant session or thread conflict"
-          }
-        }
-      }
-    },
-    "/v5/agent/{sessionId}/pause-state": {
-      "get": {
-        "operationId": "v5AgentPauseState",
-        "summary": "Get durable Assistant pause and question state",
-        "tags": [
-          "Agent"
-        ],
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Assistant pause state",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AssistantPauseStateResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Session not found"
-          },
-          "409": {
-            "description": "Invalid session pause state"
-          },
-          "503": {
-            "description": "Assistant manager temporarily unavailable"
-          }
-        }
-      }
-    },
-    "/v5/agent/answer": {
-      "post": {
-        "operationId": "v5AgentAnswer",
-        "summary": "Answer a durable Assistant question",
-        "tags": [
-          "Agent"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AssistantAnswerRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Answer accepted and session resume requested",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AssistantAnswerResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request body"
-          },
-          "404": {
-            "description": "Session or question not found"
-          },
-          "409": {
-            "description": "Question has already resumed or cannot accept an answer"
-          }
-        }
-      }
-    },
-    "/v5/agent/data/{sessionId}/strategy": {
-      "get": {
-        "operationId": "v5AgentStrategy",
-        "summary": "Get the latest customer-safe Assistant extraction strategy",
-        "description": "Returns strategy null when the session exists but no build strategy is available yet.",
-        "tags": [
-          "Agent"
-        ],
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Latest extraction strategy, or null while unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AssistantStrategyResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Session not found"
-          }
-        }
-      }
-    },
-    "/v5/agent/{sessionId}/interrupt": {
-      "post": {
-        "operationId": "v5AgentInterrupt",
-        "summary": "Safely interrupt an active Assistant session",
-        "tags": [
-          "Agent"
-        ],
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Interrupt accepted or the session was already paused",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AssistantControlResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Session not found for the authenticated team"
-          },
-          "409": {
-            "description": "Session cannot be interrupted from its current state"
-          }
-        }
-      }
-    },
-    "/v5/agent/{sessionId}/resume": {
-      "post": {
-        "operationId": "v5AgentResume",
-        "summary": "Resume an inactive or interrupted Assistant session",
-        "description": "Resumes with the persona persisted on the session, preserving Lighthouse versus Julie behavior.",
-        "tags": [
-          "Agent"
-        ],
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Resume accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AssistantResumeResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Session not found for the authenticated team"
-          },
-          "409": {
-            "description": "Session is already active or cannot be resumed"
-          }
-        }
-      }
-    },
-    "/v5/agent/{sessionId}/stop": {
-      "post": {
-        "operationId": "v5AgentStop",
-        "summary": "Stop an active Assistant session",
-        "tags": [
-          "Agent"
-        ],
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Stop accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AssistantControlResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Session not found for the authenticated team"
-          },
-          "409": {
-            "description": "Session is not active"
-          }
-        }
-      }
     }
   },
   "components": {
@@ -18417,6 +19231,26 @@
         ]
       },
       "StringLengthRule": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Attribution"
+          },
+          {
+            "type": "object",
+            "required": [
+              "value"
+            ],
+            "properties": {
+              "value": {
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          }
+        ]
+      },
+      "StringHtmlElementCountRule": {
+        "description": "Bound on how many HTML elements the text contains. An element is an opening or\nself-closing tag (e.g. `<h1>Foo</h1> bar` counts 1, `<h1>Foo</h1> <p>bar</p>` counts 2);\nclosing tags, comments, and doctypes don't count.\n",
         "allOf": [
           {
             "$ref": "#/components/schemas/Attribution"
@@ -18719,6 +19553,12 @@
           "maxLength": {
             "$ref": "#/components/schemas/StringLengthRule"
           },
+          "minHtmlElements": {
+            "$ref": "#/components/schemas/StringHtmlElementCountRule"
+          },
+          "maxHtmlElements": {
+            "$ref": "#/components/schemas/StringHtmlElementCountRule"
+          },
           "format": {
             "$ref": "#/components/schemas/StringFormatRule"
           }
@@ -18754,6 +19594,80 @@
           }
         }
       },
+      "ObjectFieldRules": {
+        "type": "object",
+        "required": [
+          "kind",
+          "properties"
+        ],
+        "description": "Rules for an object field. `properties` maps each sub-field name to its own rules\n(recursively a `FieldValidationRules`), so nested objects can be validated to any depth.\n",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "OBJECT"
+            ]
+          },
+          "presence": {
+            "$ref": "#/components/schemas/PresenceRule"
+          },
+          "uniqueness": {
+            "$ref": "#/components/schemas/UniquenessRule"
+          },
+          "properties": {
+            "type": "object",
+            "description": "Per-sub-field rules, keyed by sub-field name.",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/FieldValidationRules"
+            }
+          }
+        }
+      },
+      "ArrayFieldRules": {
+        "type": "object",
+        "required": [
+          "kind"
+        ],
+        "description": "Rules for an array field. `items` are the rules applied to every element of the array\n(recursively a `FieldValidationRules`).\n",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "ARRAY"
+            ]
+          },
+          "presence": {
+            "$ref": "#/components/schemas/PresenceRule"
+          },
+          "uniqueness": {
+            "$ref": "#/components/schemas/UniquenessRule"
+          },
+          "items": {
+            "$ref": "#/components/schemas/FieldValidationRules"
+          }
+        }
+      },
+      "OtherFieldRules": {
+        "type": "object",
+        "required": [
+          "kind"
+        ],
+        "description": "Fallback rules for fields with no richer rule shape (e.g. booleans).",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "OTHER"
+            ]
+          },
+          "presence": {
+            "$ref": "#/components/schemas/PresenceRule"
+          },
+          "uniqueness": {
+            "$ref": "#/components/schemas/UniquenessRule"
+          }
+        }
+      },
       "FieldValidationRules": {
         "oneOf": [
           {
@@ -18761,6 +19675,15 @@
           },
           {
             "$ref": "#/components/schemas/NumberFieldRules"
+          },
+          {
+            "$ref": "#/components/schemas/ObjectFieldRules"
+          },
+          {
+            "$ref": "#/components/schemas/ArrayFieldRules"
+          },
+          {
+            "$ref": "#/components/schemas/OtherFieldRules"
           }
         ],
         "discriminator": {
@@ -18772,6 +19695,557 @@
         "description": "Map keyed by schema field name, with the per-field data quality rules for that field.",
         "additionalProperties": {
           "$ref": "#/components/schemas/FieldValidationRules"
+        }
+      },
+      "ExtractionStrategySummary": {
+        "type": "object",
+        "required": [
+          "approach",
+          "summary",
+          "dataSource"
+        ],
+        "properties": {
+          "approach": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "dataSource": {
+            "type": "object",
+            "required": [
+              "type",
+              "endpoints",
+              "interactionStyle",
+              "selectors"
+            ],
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "endpoints": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "interactionStyle": {
+                "type": "string"
+              },
+              "selectors": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "intervalSeconds": {
+            "type": "number",
+            "nullable": true,
+            "description": "Realtime polling interval in seconds, when applicable."
+          }
+        }
+      },
+      "AgentPromptRequest": {
+        "type": "object",
+        "required": [
+          "prompt"
+        ],
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sessionId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "newSessionId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "threadId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "backgroundMode": {
+            "type": "boolean"
+          },
+          "model": {
+            "type": "string",
+            "enum": [
+              "fast",
+              "balanced",
+              "smart"
+            ]
+          },
+          "templateId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "templateVersion": {
+            "type": "integer",
+            "minimum": 1,
+            "nullable": true
+          },
+          "productType": {
+            "type": "string",
+            "enum": [
+              "workflow",
+              "realtime"
+            ]
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "notificationChannelIds": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      },
+      "AgentPromptResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status",
+          "message"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "jobId",
+              "sessionId",
+              "threadId",
+              "workflowId"
+            ],
+            "properties": {
+              "jobId": {
+                "type": "string",
+                "nullable": true
+              },
+              "inputEventId": {
+                "type": "string"
+              },
+              "sessionId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "threadId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "workflowId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "existed": {
+                "type": "boolean"
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "AssistantQuestion": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "question",
+          "header",
+          "options",
+          "answerType"
+        ],
+        "properties": {
+          "question": {
+            "type": "string"
+          },
+          "header": {
+            "type": "string"
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "label",
+                "description"
+              ],
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "answerType": {
+            "type": "string",
+            "enum": [
+              "single",
+              "multi",
+              "freeform"
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "WorkflowAssistantMessageRequest": {
+        "type": "object",
+        "required": [
+          "prompt"
+        ],
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Natural-language instructions for updating the existing workflow."
+          },
+          "threadId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "Assistant thread to continue. Omit to use the workflow's latest Assistant thread."
+          }
+        }
+      },
+      "WorkflowAssistantMessageResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status",
+          "message"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "jobId",
+              "sessionId",
+              "threadId",
+              "workflowId"
+            ],
+            "properties": {
+              "jobId": {
+                "type": "string",
+                "nullable": true
+              },
+              "inputEventId": {
+                "type": "string"
+              },
+              "sessionId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "threadId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "workflowId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "existed": {
+                "type": "boolean"
+              },
+              "alreadyBootstrapped": {
+                "type": "boolean"
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "AssistantPauseStateResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "paused",
+              "pause",
+              "pendingQuestion"
+            ],
+            "properties": {
+              "paused": {
+                "type": "boolean"
+              },
+              "pause": {
+                "type": "object",
+                "nullable": true,
+                "required": [
+                  "id",
+                  "reason",
+                  "status",
+                  "pausedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string",
+                    "enum": [
+                      "question",
+                      "interrupt"
+                    ]
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "resuming"
+                    ]
+                  },
+                  "threadId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "pausedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "resumeRequestedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "pendingQuestion": {
+                "type": "object",
+                "nullable": true,
+                "required": [
+                  "questionId",
+                  "questions",
+                  "askedAt"
+                ],
+                "properties": {
+                  "questionId": {
+                    "type": "string"
+                  },
+                  "threadId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "questions": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/AssistantQuestion"
+                    }
+                  },
+                  "askedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          }
+        }
+      },
+      "AssistantAnswerRequest": {
+        "type": "object",
+        "required": [
+          "sessionId",
+          "questionId",
+          "answers"
+        ],
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "questionId": {
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "answers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Question-index-to-answer map. Freeform answers use the `_freeform` key."
+          }
+        }
+      },
+      "AssistantAnswerResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status",
+          "message"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "success"
+            ],
+            "properties": {
+              "success": {
+                "type": "boolean",
+                "enum": [
+                  true
+                ]
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "AssistantStrategyResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "strategy"
+            ],
+            "properties": {
+              "strategy": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ExtractionStrategySummary"
+                  }
+                ],
+                "nullable": true
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          }
+        }
+      },
+      "AssistantControlResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "success"
+            ],
+            "properties": {
+              "success": {
+                "type": "boolean"
+              },
+              "delivery": {
+                "type": "string",
+                "enum": [
+                  "durable",
+                  "already_paused"
+                ]
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          }
+        }
+      },
+      "AssistantResumeResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status",
+          "message"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "jobId",
+              "sessionId"
+            ],
+            "properties": {
+              "jobId": {
+                "type": "string"
+              },
+              "sessionId": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
         }
       },
       "EmailChannelConfig": {
@@ -20354,7 +21828,7 @@
                   "cloakbrowser",
                   "brightdata"
                 ],
-                "description": "Explicit Scrape V2 worker override. BrightData is blocked in crawler runtime."
+                "description": "Explicit Scrape V2 worker override. BrightData is blocked in crawler runtime. camoufox is retired and remapped to patchright (accepted for backwards compatibility with stored configs)."
               },
               "proxy": {
                 "type": "string",
@@ -20582,6 +22056,10 @@
           "jobId": {
             "type": "string",
             "description": "Internal: Job ID for workflow tracking"
+          },
+          "workflowId": {
+            "type": "string",
+            "description": "Internal: Owning workflow (scraperId) for BrightData cost attribution"
           },
           "dataKey": {
             "type": "string",
@@ -20710,7 +22188,7 @@
                   "cloakbrowser",
                   "brightdata"
                 ],
-                "description": "Explicit Scrape V2 worker override. BrightData is blocked in crawler runtime."
+                "description": "Explicit Scrape V2 worker override. BrightData is blocked in crawler runtime. camoufox is retired and remapped to patchright (accepted for backwards compatibility with stored configs)."
               },
               "proxy": {
                 "type": "string",
@@ -20938,6 +22416,10 @@
           "jobId": {
             "type": "string",
             "description": "Internal: Job ID for workflow tracking"
+          },
+          "workflowId": {
+            "type": "string",
+            "description": "Internal: Owning workflow (scraperId) for BrightData cost attribution"
           },
           "dataKey": {
             "type": "string",
@@ -21083,7 +22565,7 @@
                   "cloakbrowser",
                   "brightdata"
                 ],
-                "description": "Explicit Scrape V2 worker override. BrightData is blocked in crawler runtime."
+                "description": "Explicit Scrape V2 worker override. BrightData is blocked in crawler runtime. camoufox is retired and remapped to patchright (accepted for backwards compatibility with stored configs)."
               },
               "proxy": {
                 "type": "string",
@@ -21311,6 +22793,10 @@
           "jobId": {
             "type": "string",
             "description": "Internal: Job ID for workflow tracking"
+          },
+          "workflowId": {
+            "type": "string",
+            "description": "Internal: Owning workflow (scraperId) for BrightData cost attribution"
           },
           "dataKey": {
             "type": "string",
@@ -21489,7 +22975,7 @@
                   "cloakbrowser",
                   "brightdata"
                 ],
-                "description": "Explicit Scrape V2 worker override. BrightData is blocked in crawler runtime."
+                "description": "Explicit Scrape V2 worker override. BrightData is blocked in crawler runtime. camoufox is retired and remapped to patchright (accepted for backwards compatibility with stored configs)."
               },
               "proxy": {
                 "type": "string",
@@ -21717,6 +23203,10 @@
           "jobId": {
             "type": "string",
             "description": "Internal: Job ID for workflow tracking"
+          },
+          "workflowId": {
+            "type": "string",
+            "description": "Internal: Owning workflow (scraperId) for BrightData cost attribution"
           },
           "dataKey": {
             "type": "string",
@@ -22209,6 +23699,11 @@
             "minLength": 1,
             "description": "Field description"
           },
+          "instruction": {
+            "type": "string",
+            "minLength": 1,
+            "description": "AI instruction for field-specific extraction or transformation guidance"
+          },
           "fieldType": {
             "default": "SCHEMA",
             "type": "string",
@@ -22229,6 +23724,10 @@
               }
             ],
             "description": "Example value for the field"
+          },
+          "shape": {
+            "nullable": true,
+            "description": "Authoritative nested shape for OBJECT/ARRAY fields. Use this for required field structure; without it, a JSON object/array example is promoted to the enforced shape at workflow creation."
           },
           "dataType": {
             "type": "string",
@@ -22256,6 +23755,9 @@
           "description",
           "dataType"
         ],
+        "additionalProperties": {
+          "nullable": true
+        },
         "title": "DataField",
         "description": "Extract and structure specific data from web pages with typed values (e.g., product prices, article titles, dates). Use this for actual data you want to capture."
       },
@@ -22385,39 +23887,6 @@
                   "$ref": "#/components/schemas/DataField"
                 },
                 {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "pattern": "^[a-zA-Z][a-zA-Z0-9_]*$"
-                    },
-                    "description": {
-                      "type": "string",
-                      "minLength": 1
-                    },
-                    "fieldType": {
-                      "type": "string",
-                      "enum": [
-                        "METADATA"
-                      ]
-                    },
-                    "metadataKey": {
-                      "type": "string",
-                      "enum": [
-                        "HTML",
-                        "MARKDOWN",
-                        "PAGE_URL"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "name",
-                    "fieldType",
-                    "metadataKey"
-                  ],
-                  "additionalProperties": true
-                },
-                {
                   "$ref": "#/components/schemas/ClassificationField"
                 },
                 {
@@ -22517,39 +23986,6 @@
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/DataField"
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "pattern": "^[a-zA-Z][a-zA-Z0-9_]*$"
-                        },
-                        "description": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "fieldType": {
-                          "type": "string",
-                          "enum": [
-                            "METADATA"
-                          ]
-                        },
-                        "metadataKey": {
-                          "type": "string",
-                          "enum": [
-                            "HTML",
-                            "MARKDOWN",
-                            "PAGE_URL"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "name",
-                        "fieldType",
-                        "metadataKey"
-                      ],
-                      "additionalProperties": true
                     },
                     {
                       "$ref": "#/components/schemas/ClassificationField"
@@ -22761,39 +24197,6 @@
                       "$ref": "#/components/schemas/DataField"
                     },
                     {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "pattern": "^[a-zA-Z][a-zA-Z0-9_]*$"
-                        },
-                        "description": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "fieldType": {
-                          "type": "string",
-                          "enum": [
-                            "METADATA"
-                          ]
-                        },
-                        "metadataKey": {
-                          "type": "string",
-                          "enum": [
-                            "HTML",
-                            "MARKDOWN",
-                            "PAGE_URL"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "name",
-                        "fieldType",
-                        "metadataKey"
-                      ],
-                      "additionalProperties": true
-                    },
-                    {
                       "$ref": "#/components/schemas/ClassificationField"
                     },
                     {
@@ -22868,6 +24271,65 @@
         "title": "DeleteSchemaResponse",
         "description": "Response for schema deletion"
       },
+      "LatestVersionSummary": {
+        "type": "object",
+        "properties": {
+          "promptPreview": {
+            "type": "string",
+            "description": "Truncated prompt prefix (capped at ~280 chars with ellipsis) for list display. null when the latest version has no prompt.",
+            "nullable": true
+          },
+          "schemaFieldNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Field names of the latest version's schema, in declared order. Empty when the version has no schema."
+          },
+          "dqRuleCount": {
+            "type": "integer",
+            "description": "Count of data-quality rule fields on the latest version (top-level keys of schemaValidationRules, which are field names)."
+          },
+          "notificationChannelCount": {
+            "type": "integer",
+            "description": "Count of distinct notification channels across all events on the latest version."
+          },
+          "frequencyInterval": {
+            "type": "string",
+            "enum": [
+              "ONLY_ONCE",
+              "EVERY_10_MINUTES",
+              "HALF_HOURLY",
+              "HOURLY",
+              "THREE_HOURLY",
+              "SIX_HOURLY",
+              "TWELVE_HOURLY",
+              "EIGHTEEN_HOURLY",
+              "DAILY",
+              "TWO_DAY",
+              "THREE_DAY",
+              "WEEKLY",
+              "BIWEEKLY",
+              "TRIWEEKLY",
+              "FOUR_WEEKS",
+              "MONTHLY",
+              "REAL_TIME",
+              "CUSTOM"
+            ],
+            "description": "Frequency interval enum of the latest version. null when the version does not control frequency.",
+            "nullable": true
+          }
+        },
+        "required": [
+          "promptPreview",
+          "schemaFieldNames",
+          "dqRuleCount",
+          "notificationChannelCount",
+          "frequencyInterval"
+        ],
+        "title": "LatestVersionSummary",
+        "description": "Content preview of the latest version for list rendering. null when the template has no published versions; omitted by create/update/duplicate responses."
+      },
       "TemplateResponse": {
         "type": "object",
         "properties": {
@@ -22899,25 +24361,13 @@
             "type": "number",
             "description": "Number of workflows linked to this template"
           },
-          "hasPrompt": {
-            "type": "boolean",
-            "description": "Whether the latest version has a prompt"
-          },
-          "hasSchema": {
-            "type": "boolean",
-            "description": "Whether the latest version has a schema"
-          },
-          "hasSchemaValidationRules": {
-            "type": "boolean",
-            "description": "Whether the latest version has schema validation rules"
-          },
-          "hasNotifications": {
-            "type": "boolean",
-            "description": "Whether the latest version has notification settings"
-          },
-          "hasFrequency": {
-            "type": "boolean",
-            "description": "Whether the latest version controls frequency"
+          "latestVersionSummary": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LatestVersionSummary"
+              }
+            ]
           },
           "archivedAt": {
             "type": "string",
@@ -23012,25 +24462,13 @@
                 "type": "number",
                 "description": "Number of workflows linked to this template"
               },
-              "hasPrompt": {
-                "type": "boolean",
-                "description": "Whether the latest version has a prompt"
-              },
-              "hasSchema": {
-                "type": "boolean",
-                "description": "Whether the latest version has a schema"
-              },
-              "hasSchemaValidationRules": {
-                "type": "boolean",
-                "description": "Whether the latest version has schema validation rules"
-              },
-              "hasNotifications": {
-                "type": "boolean",
-                "description": "Whether the latest version has notification settings"
-              },
-              "hasFrequency": {
-                "type": "boolean",
-                "description": "Whether the latest version controls frequency"
+              "latestVersionSummary": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LatestVersionSummary"
+                  }
+                ]
               },
               "archivedAt": {
                 "type": "string",
@@ -23093,6 +24531,11 @@
                             "type": "string",
                             "description": "Field description"
                           },
+                          "instruction": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "AI instruction for field-specific extraction or transformation guidance"
+                          },
                           "fieldType": {
                             "type": "string",
                             "description": "Field type (SCHEMA, CLASSIFICATION, etc.)"
@@ -23100,6 +24543,10 @@
                           "example": {
                             "nullable": true,
                             "description": "Example value (string, array, or object for OBJECT/ARRAY dataTypes)"
+                          },
+                          "shape": {
+                            "nullable": true,
+                            "description": "Authoritative nested shape for OBJECT/ARRAY fields; without it, a JSON object/array example is promoted to the enforced shape at workflow creation."
                           },
                           "dataType": {
                             "type": "string",
@@ -23133,7 +24580,10 @@
                         },
                         "required": [
                           "name"
-                        ]
+                        ],
+                        "additionalProperties": {
+                          "nullable": true
+                        }
                       },
                       "nullable": true,
                       "description": "Resolved schema fields from data_schemas"
@@ -23258,6 +24708,10 @@
                                   "type": "string"
                                 },
                                 "description": "Cron expressions when type=cron"
+                              },
+                              "timezone": {
+                                "type": "string",
+                                "description": "IANA timezone for cron expressions (e.g. 'America/New_York'). Defaults to UTC."
                               }
                             },
                             "required": [
@@ -23389,25 +24843,13 @@
                 "type": "number",
                 "description": "Number of workflows linked to this template"
               },
-              "hasPrompt": {
-                "type": "boolean",
-                "description": "Whether the latest version has a prompt"
-              },
-              "hasSchema": {
-                "type": "boolean",
-                "description": "Whether the latest version has a schema"
-              },
-              "hasSchemaValidationRules": {
-                "type": "boolean",
-                "description": "Whether the latest version has schema validation rules"
-              },
-              "hasNotifications": {
-                "type": "boolean",
-                "description": "Whether the latest version has notification settings"
-              },
-              "hasFrequency": {
-                "type": "boolean",
-                "description": "Whether the latest version controls frequency"
+              "latestVersionSummary": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LatestVersionSummary"
+                  }
+                ]
               },
               "archivedAt": {
                 "type": "string",
@@ -23511,25 +24953,13 @@
                 "type": "number",
                 "description": "Number of workflows linked to this template"
               },
-              "hasPrompt": {
-                "type": "boolean",
-                "description": "Whether the latest version has a prompt"
-              },
-              "hasSchema": {
-                "type": "boolean",
-                "description": "Whether the latest version has a schema"
-              },
-              "hasSchemaValidationRules": {
-                "type": "boolean",
-                "description": "Whether the latest version has schema validation rules"
-              },
-              "hasNotifications": {
-                "type": "boolean",
-                "description": "Whether the latest version has notification settings"
-              },
-              "hasFrequency": {
-                "type": "boolean",
-                "description": "Whether the latest version controls frequency"
+              "latestVersionSummary": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LatestVersionSummary"
+                  }
+                ]
               },
               "archivedAt": {
                 "type": "string",
@@ -23602,6 +25032,19 @@
         "title": "TemplateArchivedResponse",
         "description": "Response for template archival"
       },
+      "DuplicateTemplateBody": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Name for the duplicate. Defaults to the source name with a collision-safe \"(Copy)\" suffix."
+          }
+        },
+        "title": "DuplicateTemplateBody",
+        "description": "Request body for duplicating a template (all versions and configs, no linked workflows)"
+      },
       "CreateTemplateVersionBody": {
         "type": "object",
         "properties": {
@@ -23627,6 +25070,11 @@
                   "type": "string",
                   "description": "Field description"
                 },
+                "instruction": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "AI instruction for field-specific extraction or transformation guidance"
+                },
                 "fieldType": {
                   "type": "string",
                   "description": "Field type (SCHEMA, CLASSIFICATION, etc.)"
@@ -23634,6 +25082,10 @@
                 "example": {
                   "nullable": true,
                   "description": "Example value (string, array, or object for OBJECT/ARRAY dataTypes)"
+                },
+                "shape": {
+                  "nullable": true,
+                  "description": "Authoritative nested shape for OBJECT/ARRAY fields; without it, a JSON object/array example is promoted to the enforced shape at workflow creation."
                 },
                 "dataType": {
                   "type": "string",
@@ -23667,7 +25119,10 @@
               },
               "required": [
                 "name"
-              ]
+              ],
+              "additionalProperties": {
+                "nullable": true
+              }
             },
             "description": "Schema fields to create a new schema inline"
           },
@@ -23781,6 +25236,10 @@
                         "type": "string"
                       },
                       "description": "Cron expressions when type=cron"
+                    },
+                    "timezone": {
+                      "type": "string",
+                      "description": "IANA timezone for cron expressions (e.g. 'America/New_York'). Defaults to UTC."
                     }
                   },
                   "required": [
@@ -23858,6 +25317,11 @@
                       "type": "string",
                       "description": "Field description"
                     },
+                    "instruction": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "AI instruction for field-specific extraction or transformation guidance"
+                    },
                     "fieldType": {
                       "type": "string",
                       "description": "Field type (SCHEMA, CLASSIFICATION, etc.)"
@@ -23865,6 +25329,10 @@
                     "example": {
                       "nullable": true,
                       "description": "Example value (string, array, or object for OBJECT/ARRAY dataTypes)"
+                    },
+                    "shape": {
+                      "nullable": true,
+                      "description": "Authoritative nested shape for OBJECT/ARRAY fields; without it, a JSON object/array example is promoted to the enforced shape at workflow creation."
                     },
                     "dataType": {
                       "type": "string",
@@ -23898,7 +25366,10 @@
                   },
                   "required": [
                     "name"
-                  ]
+                  ],
+                  "additionalProperties": {
+                    "nullable": true
+                  }
                 },
                 "nullable": true,
                 "description": "Resolved schema fields from data_schemas"
@@ -24023,6 +25494,10 @@
                             "type": "string"
                           },
                           "description": "Cron expressions when type=cron"
+                        },
+                        "timezone": {
+                          "type": "string",
+                          "description": "IANA timezone for cron expressions (e.g. 'America/New_York'). Defaults to UTC."
                         }
                       },
                       "required": [
@@ -24809,6 +26284,10 @@
             },
             "description": "Cron expressions for custom schedules. Overrides the interval setting for fine-grained control"
           },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone for cron `schedules` (e.g. 'America/New_York'). Defaults to UTC. Cron schedules only."
+          },
           "location": {
             "$ref": "#/components/schemas/Location"
           },
@@ -24862,6 +26341,7 @@
         "properties": {
           "fieldName": {
             "type": "string",
+            "minLength": 1,
             "description": "Name of the field to monitor"
           },
           "operator": {
@@ -24985,6 +26465,10 @@
               "type": "string"
             },
             "description": "Cron expressions for custom schedules. Overrides the interval setting for fine-grained control"
+          },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone for cron `schedules` (e.g. 'America/New_York'). Defaults to UTC. Cron schedules only."
           },
           "bypassPreview": {
             "default": false,
@@ -25143,6 +26627,10 @@
             },
             "description": "Cron expressions for custom schedules"
           },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone for cron `schedules` (e.g. 'America/New_York'). Defaults to UTC. Cron schedules only."
+          },
           "templateVersion": {
             "readOnly": true,
             "description": "Reserved: only valid in the WorkflowFromTemplate variant."
@@ -25166,18 +26654,6 @@
             },
             "minItems": 1,
             "description": "List of URLs to scrape. Can be a single URL or multiple URLs to scrape across different pages or domains."
-          },
-          "navigationMode": {
-            "default": "single-page",
-            "type": "string",
-            "enum": [
-              "single-page",
-              "paginated-page",
-              "page-and-detail",
-              "agentic-navigation",
-              "all-pages"
-            ],
-            "description": "Navigation mode for scraping"
           },
           "name": {
             "type": "string",
@@ -25240,6 +26716,10 @@
             },
             "description": "Cron expressions for custom schedules. Overrides the interval setting for fine-grained control"
           },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone for cron `schedules` (e.g. 'America/New_York'). Defaults to UTC. Cron schedules only."
+          },
           "bypassPreview": {
             "default": false,
             "type": "boolean",
@@ -25259,32 +26739,6 @@
           "additionalData": {
             "nullable": true,
             "description": "Additional data for the workflow (e.g. IDs from your system to link data)"
-          },
-          "maxPages": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 100000,
-            "description": "Maximum pages to crawl (default: 10,000, max: 100,000). Only used when navigationMode is 'all-pages'"
-          },
-          "maxDepth": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 200,
-            "description": "Maximum crawl depth (default: 50, max: 200). Only used when navigationMode is 'all-pages'"
-          },
-          "pathsFilterIn": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Regex patterns to include specific paths during crawling. Only used when navigationMode is 'all-pages'"
-          },
-          "pathsFilterOut": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Regex patterns to exclude specific paths during crawling. Only used when navigationMode is 'all-pages'"
           },
           "pageNumbers": {
             "type": "array",
@@ -25327,18 +26781,6 @@
             "minItems": 1,
             "description": "List of URLs to scrape. Can be a single URL or multiple URLs to scrape across different pages or domains."
           },
-          "navigationMode": {
-            "default": "single-page",
-            "type": "string",
-            "enum": [
-              "single-page",
-              "paginated-page",
-              "page-and-detail",
-              "agentic-navigation",
-              "all-pages"
-            ],
-            "description": "Navigation mode for scraping"
-          },
           "name": {
             "type": "string",
             "minLength": 1,
@@ -25400,6 +26842,10 @@
             },
             "description": "Cron expressions for custom schedules. Overrides the interval setting for fine-grained control"
           },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone for cron `schedules` (e.g. 'America/New_York'). Defaults to UTC. Cron schedules only."
+          },
           "bypassPreview": {
             "default": false,
             "type": "boolean",
@@ -25419,32 +26865,6 @@
           "additionalData": {
             "nullable": true,
             "description": "Additional data for the workflow (e.g. IDs from your system to link data)"
-          },
-          "maxPages": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 100000,
-            "description": "Maximum pages to crawl (default: 10,000, max: 100,000). Only used when navigationMode is 'all-pages'"
-          },
-          "maxDepth": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 200,
-            "description": "Maximum crawl depth (default: 50, max: 200). Only used when navigationMode is 'all-pages'"
-          },
-          "pathsFilterIn": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Regex patterns to include specific paths during crawling. Only used when navigationMode is 'all-pages'"
-          },
-          "pathsFilterOut": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Regex patterns to exclude specific paths during crawling. Only used when navigationMode is 'all-pages'"
           },
           "pageNumbers": {
             "type": "array",
@@ -25569,6 +26989,10 @@
             },
             "description": "Cron expressions for custom schedules. Overrides the interval setting for fine-grained control"
           },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone for cron `schedules` (e.g. 'America/New_York'). Defaults to UTC. Cron schedules only."
+          },
           "bypassPreview": {
             "default": false,
             "type": "boolean",
@@ -25660,10 +27084,6 @@
           "message": {
             "type": "string",
             "description": "Success message"
-          },
-          "deprecationNotice": {
-            "type": "string",
-            "description": "Optional deprecation notice for legacy navigation modes"
           }
         },
         "required": [
@@ -26072,7 +27492,8 @@
           "STRING",
           "SECRET",
           "OBJECT",
-          "ARRAY"
+          "ARRAY",
+          "NUMBER"
         ],
         "title": "VariableDataType",
         "description": "The data type of the variable value"
@@ -26272,6 +27693,10 @@
             },
             "description": "Cron expressions for custom schedules. Overrides the interval setting for fine-grained control"
           },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone for cron `schedules` (e.g. 'America/New_York'). Defaults to UTC. Cron schedules only."
+          },
           "bypassPreview": {
             "default": false,
             "type": "boolean",
@@ -26341,435 +27766,6 @@
         ],
         "title": "WorkflowCreateRequest",
         "description": "Create a workflow using natural-language instructions. Navigation is handled automatically for new integrations."
-      },
-      "ExtractionStrategySummary": {
-        "type": "object",
-        "required": [
-          "approach",
-          "summary",
-          "dataSource"
-        ],
-        "properties": {
-          "approach": {
-            "type": "string"
-          },
-          "summary": {
-            "type": "string"
-          },
-          "dataSource": {
-            "type": "object",
-            "required": [
-              "type",
-              "endpoints",
-              "interactionStyle",
-              "selectors"
-            ],
-            "properties": {
-              "type": {
-                "type": "string"
-              },
-              "endpoints": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "interactionStyle": {
-                "type": "string"
-              },
-              "selectors": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "intervalSeconds": {
-            "type": "number",
-            "nullable": true,
-            "description": "Realtime polling interval in seconds, when applicable."
-          }
-        }
-      },
-      "AssistantQuestion": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "question",
-          "header",
-          "options",
-          "answerType"
-        ],
-        "properties": {
-          "question": {
-            "type": "string"
-          },
-          "header": {
-            "type": "string"
-          },
-          "options": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "required": [
-                "label",
-                "description"
-              ],
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "answerType": {
-            "type": "string",
-            "enum": [
-              "single",
-              "multi",
-              "freeform"
-            ]
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": true
-          }
-        }
-      },
-      "WorkflowAssistantMessageRequest": {
-        "type": "object",
-        "required": [
-          "prompt"
-        ],
-        "properties": {
-          "prompt": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Natural-language instructions for updating the existing workflow."
-          },
-          "threadId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true,
-            "description": "Assistant thread to continue. Omit to use the workflow's latest Assistant thread."
-          }
-        }
-      },
-      "WorkflowAssistantMessageResponse": {
-        "type": "object",
-        "required": [
-          "data",
-          "status",
-          "message"
-        ],
-        "properties": {
-          "data": {
-            "type": "object",
-            "required": [
-              "jobId",
-              "sessionId",
-              "threadId",
-              "workflowId"
-            ],
-            "properties": {
-              "jobId": {
-                "type": "string",
-                "nullable": true
-              },
-              "inputEventId": {
-                "type": "string"
-              },
-              "sessionId": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "threadId": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "workflowId": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "existed": {
-                "type": "boolean"
-              },
-              "alreadyBootstrapped": {
-                "type": "boolean"
-              }
-            }
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "success"
-            ]
-          },
-          "message": {
-            "type": "string"
-          }
-        }
-      },
-      "AssistantPauseStateResponse": {
-        "type": "object",
-        "required": [
-          "data",
-          "status"
-        ],
-        "properties": {
-          "data": {
-            "type": "object",
-            "required": [
-              "paused",
-              "pause",
-              "pendingQuestion"
-            ],
-            "properties": {
-              "paused": {
-                "type": "boolean"
-              },
-              "pause": {
-                "type": "object",
-                "nullable": true,
-                "required": [
-                  "id",
-                  "reason",
-                  "status",
-                  "pausedAt"
-                ],
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  },
-                  "reason": {
-                    "type": "string",
-                    "enum": [
-                      "question",
-                      "interrupt"
-                    ]
-                  },
-                  "status": {
-                    "type": "string",
-                    "enum": [
-                      "active",
-                      "resuming"
-                    ]
-                  },
-                  "threadId": {
-                    "type": "string",
-                    "format": "uuid"
-                  },
-                  "pausedAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "resumeRequestedAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                }
-              },
-              "pendingQuestion": {
-                "type": "object",
-                "nullable": true,
-                "required": [
-                  "questionId",
-                  "questions",
-                  "askedAt"
-                ],
-                "properties": {
-                  "questionId": {
-                    "type": "string"
-                  },
-                  "threadId": {
-                    "type": "string",
-                    "format": "uuid"
-                  },
-                  "questions": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/AssistantQuestion"
-                    }
-                  },
-                  "askedAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                }
-              }
-            }
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "success"
-            ]
-          }
-        }
-      },
-      "AssistantAnswerRequest": {
-        "type": "object",
-        "required": [
-          "sessionId",
-          "questionId",
-          "answers"
-        ],
-        "properties": {
-          "sessionId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "questionId": {
-            "type": "string"
-          },
-          "threadId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "answers": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "Question-index-to-answer map. Freeform answers use the `_freeform` key."
-          }
-        }
-      },
-      "AssistantAnswerResponse": {
-        "type": "object",
-        "required": [
-          "data",
-          "status",
-          "message"
-        ],
-        "properties": {
-          "data": {
-            "type": "object",
-            "required": [
-              "success"
-            ],
-            "properties": {
-              "success": {
-                "type": "boolean",
-                "enum": [
-                  true
-                ]
-              }
-            }
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "success"
-            ]
-          },
-          "message": {
-            "type": "string"
-          }
-        }
-      },
-      "AssistantStrategyResponse": {
-        "type": "object",
-        "required": [
-          "data",
-          "status"
-        ],
-        "properties": {
-          "data": {
-            "type": "object",
-            "required": [
-              "strategy"
-            ],
-            "properties": {
-              "strategy": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ExtractionStrategySummary"
-                  }
-                ],
-                "nullable": true
-              }
-            }
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "success"
-            ]
-          }
-        }
-      },
-      "AssistantControlResponse": {
-        "type": "object",
-        "required": [
-          "data",
-          "status"
-        ],
-        "properties": {
-          "data": {
-            "type": "object",
-            "required": [
-              "success"
-            ],
-            "properties": {
-              "success": {
-                "type": "boolean"
-              },
-              "delivery": {
-                "type": "string",
-                "enum": [
-                  "durable",
-                  "already_paused"
-                ]
-              }
-            }
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "success"
-            ]
-          }
-        }
-      },
-      "AssistantResumeResponse": {
-        "type": "object",
-        "required": [
-          "data",
-          "status",
-          "message"
-        ],
-        "properties": {
-          "data": {
-            "type": "object",
-            "required": [
-              "jobId",
-              "sessionId"
-            ],
-            "properties": {
-              "jobId": {
-                "type": "string"
-              },
-              "sessionId": {
-                "type": "string",
-                "format": "uuid"
-              }
-            }
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "success"
-            ]
-          },
-          "message": {
-            "type": "string"
-          }
-        }
       }
     },
     "securitySchemes": {


### PR DESCRIPTION
## Summary
- refresh the reviewed public Agent OpenAPI contract
- add `client.assistant.createRealtimeWorkflow`
- hardcode `productType: realtime` and map notification channel IDs, tags, and optional retry session ID
- validate stable workflow/session/thread identity while preserving nullable idempotent `jobId`

## Validation
- Assistant service: 18 passing
- workflow/change compatibility: 9 passing
- Node SDK typecheck and CJS/ESM/IIFE/DTS builds passing
- touched files pass Biome

## Dependency
Merge/publish only after backend PR https://github.com/kadoa-org/kadoa-backend/pull/10699 is merged and deployed.

Linear: https://linear.app/kadoa/issue/KAD-17771
