### PR TITLE
feat(node-sdk): expose scrape response discovery

### DIFF
--- a/sdks/node/test/unit/openapi-spec.test.ts
+++ b/sdks/node/test/unit/openapi-spec.test.ts
@@ -18,4 +18,19 @@ describe("published OpenAPI source", () => {
       spec.paths["/v5/agent/workflows/{workflowId}/timeline"].get.operationId,
     ).toBe("v5AgentWorkflowAssistantTimeline");
   });
+
+  test("includes bounded public scrape response discovery", () => {
+    const spec = JSON.parse(readFileSync(specPath, "utf8"));
+    const request = spec.paths["/v4/scrape"].post.requestBody.content["application/json"].schema;
+    const response = spec.paths["/v4/scrape"].post.responses["200"].content["application/json"].schema;
+
+    expect(request.properties.discoverResponses.type).toBe("boolean");
+    expect(response.properties.capturedResponses.items.properties).toMatchObject({
+      method: { type: "string" },
+      resourceType: { type: "string" },
+      contentType: { type: "string" },
+      sizeBytes: { type: "integer" },
+      bodyTruncated: { type: "boolean" },
+    });
+  });
 });

--- a/sdks/node/test/unit/scrape.service.test.ts
+++ b/sdks/node/test/unit/scrape.service.test.ts
@@ -72,4 +72,19 @@ describe("ScrapeService", () => {
     expect(config.headers["x-api-key"]).toBe("tk-test");
     expect(config.headers["Authorization"]).toBeUndefined();
   });
+
+  test("passes bounded response discovery to the public scrape API", async () => {
+    const client = new KadoaClient({ apiKey: "tk-test" });
+    const { config } = await captureScrape(client, {
+      url: "https://example.com/dashboard",
+      discoverResponses: true,
+      browserActions: [{ type: "wait", wait_time_s: 1 }],
+    });
+
+    expect(JSON.parse(config.data)).toEqual({
+      url: "https://example.com/dashboard",
+      discoverResponses: true,
+      browserActions: [{ type: "wait", wait_time_s: 1 }],
+    });
+  });
 });

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -8778,7 +8778,7 @@
                     },
                     "scheduledWorkflows": {
                       "type": "integer",
-                      "description": "ACTIVE workflows with an active schedule (auto-run, roll over to next cycle)"
+                      "description": "ACTIVE workflows with an active schedule OR on a live real-time monitor lane (REAL_TIME, SHELLY_REAL_TIME_SCRIPT) — both auto-run and roll over to the next cycle"
                     },
                     "workflows": {
                       "type": "array",
@@ -8799,7 +8799,7 @@
                           },
                           "scheduled": {
                             "type": "boolean",
-                            "description": "ACTIVE and on an active schedule (recurring); else completed/one-off"
+                            "description": "ACTIVE and either on an active schedule or a live real-time monitor (recurring); else completed/one-off"
                           },
                           "firstRunAt": {
                             "type": "string",
@@ -14619,6 +14619,10 @@
                     "maxItems": 20,
                     "description": "Substrings matched against network response URLs (browser workers only). The worker hooks every response the page makes and returns the body of each whose URL contains any of these substrings, in `capturedResponses`. Use this to read data that arrives via XHR/fetch and is NOT in the DOM — SPA dashboards (Tableau VizQL, Power BI) where values come back in a JSON/command response. Triggers a browser worker; pair with `browserActions` (clicks/waits) to drive the requests you want captured."
                   },
+                  "discoverResponses": {
+                    "type": "boolean",
+                    "description": "Discover a bounded set of useful document, XHR, and fetch responses without supplying URL patterns. Browser workers return response metadata and small text bodies in `capturedResponses`. Intended for ad hoc exploration; server-owned count and byte limits always apply."
+                  },
                   "waitUntil": {
                     "type": "string",
                     "enum": [
@@ -14653,12 +14657,13 @@
                     "type": "string",
                     "enum": [
                       "auto",
+                      "direct",
                       "dc",
                       "isp",
                       "residential",
                       "stealth"
                     ],
-                    "description": "Proxy tier: auto (smart selection), dc (datacenter), isp, residential, or stealth to route through the anti-bot providers for sites that block bots. Stealth providers use their own egress and pricing. Default: auto"
+                    "description": "Proxy tier: auto (smart selection), direct (Squid server egress without location guarantees), dc (datacenter), isp, residential, or stealth to route through the anti-bot providers for sites that block bots. Stealth providers use their own egress and pricing. Default: auto"
                   },
                   "format": {
                     "default": "html",
@@ -15014,18 +15019,38 @@
                             "type": "number",
                             "description": "HTTP status code of the captured response"
                           },
+                          "method": {
+                            "type": "string",
+                            "description": "HTTP method of the originating browser request"
+                          },
+                          "resourceType": {
+                            "type": "string",
+                            "description": "Browser resource type, such as document, xhr, or fetch"
+                          },
+                          "contentType": {
+                            "type": "string",
+                            "description": "Response Content-Type header when available"
+                          },
+                          "sizeBytes": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Observed response body size in bytes"
+                          },
                           "body": {
                             "type": "string",
-                            "description": "Response body as text"
+                            "description": "Response body as text when it is safe and within capture limits"
+                          },
+                          "bodyTruncated": {
+                            "type": "boolean",
+                            "description": "Whether the returned body was truncated by server limits"
                           }
                         },
                         "required": [
                           "url",
-                          "status",
-                          "body"
+                          "status"
                         ]
                       },
-                      "description": "Bodies of network responses whose URL matched a `captureResponses` substring, in arrival order. Present only when `captureResponses` was set and at least one response matched."
+                      "description": "Bounded network response metadata and optional text bodies, in arrival order. Present when `captureResponses` or `discoverResponses` was requested and at least one response matched."
                     },
                     "statusCode": {
                       "type": "number",
@@ -15132,11 +15157,12 @@
                               "proxy": {
                                 "type": "string",
                                 "enum": [
+                                  "direct",
                                   "dc",
                                   "isp",
                                   "residential"
                                 ],
-                                "description": "Proxy type: datacenter, ISP, or residential",
+                                "description": "Proxy type: direct Squid egress, datacenter, ISP, or residential",
                                 "nullable": true
                               },
                               "location": {
@@ -23351,6 +23377,7 @@
                 "type": "string",
                 "enum": [
                   "auto",
+                  "direct",
                   "dc",
                   "resi",
                   "isp"
@@ -23711,6 +23738,7 @@
                 "type": "string",
                 "enum": [
                   "auto",
+                  "direct",
                   "dc",
                   "resi",
                   "isp"
@@ -24088,6 +24116,7 @@
                 "type": "string",
                 "enum": [
                   "auto",
+                  "direct",
                   "dc",
                   "resi",
                   "isp"
@@ -24498,6 +24527,7 @@
                 "type": "string",
                 "enum": [
                   "auto",
+                  "direct",
                   "dc",
                   "resi",
                   "isp"


### PR DESCRIPTION
## Summary

- sync the public scrape OpenAPI contract for bounded automatic response discovery
- expose `discoverResponses` on `ScrapeRequest`
- expose captured response method, resource type, content type, byte size, optional body, and truncation state
- add contract and request-forwarding tests

## Dependency

This publishes the typed client contract for [kadoa-backend#10947](https://github.com/kadoa-org/kadoa-backend/pull/10947). Merge and deploy the backend capability before releasing this SDK version.

## Validation

- 142 Node SDK unit tests passed
- Node SDK TypeScript check passed against freshly generated sources
- generated sources were produced from the vendored spec and are intentionally gitignored
- E2E tests were not run because this workspace has no `KADOA_API_KEY` or public API URI

Linear: [KAD-18760](https://linear.app/kadoa/issue/KAD-18760/mcp-expose-bounded-network-analyzer-exploration)