### PR TITLE
KAD-18811: expose personal Inbox in Node SDK

### DIFF
--- a/sdks/node/src/client/api-registry.ts
+++ b/sdks/node/src/client/api-registry.ts
@@ -5,6 +5,7 @@ import {
   type BaseAPI,
   Configuration,
   DataValidationApi,
+  InboxApi,
   MeApi,
   NotificationsApi,
   SchemasApi,
@@ -77,6 +78,10 @@ export class ApiRegistry {
 
   get notifications(): NotificationsApi {
     return this.get(NotificationsApi);
+  }
+
+  get inbox(): InboxApi {
+    return this.get(InboxApi);
   }
 
   get templates(): TemplatesApi {

--- a/sdks/node/src/client/apis.acl.ts
+++ b/sdks/node/src/client/apis.acl.ts
@@ -2,6 +2,7 @@ export {
   AgentApi,
   Configuration,
   DataValidationApi,
+  InboxApi,
   MeApi,
   NotificationsApi,
   SchemasApi,

--- a/sdks/node/src/client/kadoa-client.ts
+++ b/sdks/node/src/client/kadoa-client.ts
@@ -8,6 +8,7 @@ import type {
   ExtractOptions,
   PreparedExtraction,
 } from "../domains/extraction/services/extraction-builder.service";
+import type { InboxService } from "../domains/inbox";
 import { Realtime, type RealtimeConfig } from "../domains/realtime";
 import type { SchemasService } from "../domains/schemas/schemas.service";
 import type { ScrapeService } from "../domains/scrape/scrape.service";
@@ -67,6 +68,7 @@ export class KadoaClient {
   public readonly extraction: ExtractionService;
   public readonly workflow: WorkflowsCoreService;
   public readonly notification: NotificationDomain;
+  public readonly inbox: InboxService;
   public readonly schema: SchemasService;
   public readonly scrape: ScrapeService;
   public readonly user: UserService;
@@ -130,6 +132,7 @@ export class KadoaClient {
     this.schema = domains.schema;
     this.scrape = domains.scrape;
     this.notification = domains.notification;
+    this.inbox = domains.inbox;
     this.template = domains.template;
     this.validation = domains.validation;
     this.variable = domains.variable;

--- a/sdks/node/src/client/wiring.ts
+++ b/sdks/node/src/client/wiring.ts
@@ -7,6 +7,7 @@ import { type CrawlerDomain, createCrawlerDomain } from "../domains/crawler";
 import { DataFetcherService } from "../domains/extraction/services/data-fetcher.service";
 import { ExtractionService } from "../domains/extraction/services/extraction.service";
 import { ExtractionBuilderService } from "../domains/extraction/services/extraction-builder.service";
+import { InboxService } from "../domains/inbox";
 import type {
   NotificationOptions,
   NotificationSettingsEventType,
@@ -84,6 +85,7 @@ export function createClientDomains(params: { client: KadoaClient }): {
   extraction: ExtractionService;
   workflow: WorkflowsCoreService;
   notification: NotificationDomain;
+  inbox: InboxService;
   schema: SchemasService;
   scrape: ScrapeService;
   user: UserService;
@@ -96,6 +98,7 @@ export function createClientDomains(params: { client: KadoaClient }): {
 
   const assistantService = new AssistantService(client.apis.agent);
   const changesService = new ChangesService(client);
+  const inboxService = new InboxService(client.apis.inbox);
   const userService = new UserService(client);
   const dataFetcherService = new DataFetcherService(client.apis.workflows);
   const channelsService = new NotificationChannelsService(
@@ -151,6 +154,7 @@ export function createClientDomains(params: { client: KadoaClient }): {
     extraction: extractionService,
     workflow: workflowsCoreService,
     notification,
+    inbox: inboxService,
     schema: schemasService,
     scrape: scrapeService,
     user: userService,

--- a/sdks/node/src/domains/inbox/inbox.acl.ts
+++ b/sdks/node/src/domains/inbox/inbox.acl.ts
@@ -1,0 +1,85 @@
+/**
+ * Inbox domain ACL.
+ * Wraps generated InboxApi responses and removes authenticated scope fields
+ * from the curated personal Inbox result.
+ */
+import {
+  type InboxItem as GeneratedInboxItem,
+  InboxItemTypeEnum as GeneratedInboxItemType,
+  type InboxItemTypeEnum as GeneratedInboxItemTypeValue,
+  type InboxListResponse as GeneratedInboxListResponse,
+  type InboxReadMutationResponse as GeneratedInboxReadMutationResponse,
+  type InboxApiInterface,
+} from "../../generated";
+
+export interface InboxApi {
+  v5InboxList: InboxApiInterface["v5InboxList"];
+  v5InboxMarkRead: InboxApiInterface["v5InboxMarkRead"];
+}
+
+export const InboxItemType = {
+  AssistantQuestion: GeneratedInboxItemType.ShellyQuestion,
+  DataQualityIssues: GeneratedInboxItemType.DataQualityIssues,
+  PreviewDataReady: GeneratedInboxItemType.SampleDataReady,
+} as const;
+
+export type InboxItemType = (typeof InboxItemType)[keyof typeof InboxItemType];
+
+const knownInboxItemTypes: Record<GeneratedInboxItemTypeValue, InboxItemType> =
+  {
+    [GeneratedInboxItemType.ShellyQuestion]: InboxItemType.AssistantQuestion,
+    [GeneratedInboxItemType.DataQualityIssues]: InboxItemType.DataQualityIssues,
+    [GeneratedInboxItemType.SampleDataReady]: InboxItemType.PreviewDataReady,
+  };
+
+export interface InboxItem {
+  id: string;
+  type: InboxItemType;
+  subjectId: string;
+  workflowId: string | null;
+  title: string;
+  payload: Record<string, unknown>;
+  isRead: boolean;
+  readAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface InboxListResult {
+  unreadCount: number;
+  items: InboxItem[];
+}
+
+export interface InboxMarkReadResult {
+  readCount: number;
+}
+
+export function mapInboxItem(item: GeneratedInboxItem): InboxItem {
+  return {
+    id: item.id,
+    type: knownInboxItemTypes[item.type] ?? item.type,
+    subjectId: item.subjectId,
+    workflowId: item.workflowId,
+    title: item.title,
+    payload: item.payload,
+    isRead: item.isRead,
+    readAt: item.readAt,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+  };
+}
+
+export function mapInboxListResponse(
+  response: GeneratedInboxListResponse,
+): InboxListResult {
+  return {
+    unreadCount: response.data.unreadCount,
+    items: response.data.items.map(mapInboxItem),
+  };
+}
+
+export function mapInboxMarkReadResponse(
+  response: GeneratedInboxReadMutationResponse,
+): InboxMarkReadResult {
+  return { readCount: response.data.readCount };
+}

--- a/sdks/node/src/domains/inbox/inbox.service.ts
+++ b/sdks/node/src/domains/inbox/inbox.service.ts
@@ -1,0 +1,20 @@
+import type {
+  InboxApi,
+  InboxListResult,
+  InboxMarkReadResult,
+} from "./inbox.acl";
+import { mapInboxListResponse, mapInboxMarkReadResponse } from "./inbox.acl";
+
+export class InboxService {
+  constructor(private readonly inboxApi: InboxApi) {}
+
+  async list(): Promise<InboxListResult> {
+    const response = await this.inboxApi.v5InboxList();
+    return mapInboxListResponse(response.data);
+  }
+
+  async markRead(itemId: string): Promise<InboxMarkReadResult> {
+    const response = await this.inboxApi.v5InboxMarkRead({ itemId });
+    return mapInboxMarkReadResponse(response.data);
+  }
+}

--- a/sdks/node/src/domains/inbox/index.ts
+++ b/sdks/node/src/domains/inbox/index.ts
@@ -1,0 +1,7 @@
+export type {
+  InboxItem,
+  InboxListResult,
+  InboxMarkReadResult,
+} from "./inbox.acl";
+export { InboxItemType } from "./inbox.acl";
+export { InboxService } from "./inbox.service";

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -11,6 +11,7 @@ export * from "./domains/assistant";
 export * from "./domains/changes";
 export * from "./domains/crawler";
 export * from "./domains/extraction";
+export * from "./domains/inbox";
 export * from "./domains/notifications";
 export * from "./domains/realtime";
 export * from "./domains/schemas";

--- a/sdks/node/test/unit/inbox.service.test.ts
+++ b/sdks/node/test/unit/inbox.service.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../src/runtime/utils/version-check", () => ({
+  checkForUpdates: () => Promise.resolve(),
+}));
+
+import {
+  type InboxItem,
+  InboxItemType,
+  type InboxItemType as InboxItemTypeValue,
+  type InboxListResult,
+  type InboxMarkReadResult,
+  KadoaClient,
+} from "../../src";
+
+const mockList = mock();
+const mockMarkRead = mock();
+
+function createTestClient(): KadoaClient {
+  const client = new KadoaClient({ apiKey: "tk-test" });
+  Object.assign(client.apis.inbox, {
+    v5InboxList: mockList,
+    v5InboxMarkRead: mockMarkRead,
+  });
+  return client;
+}
+
+const baseItem = {
+  id: "33333333-3333-4333-8333-333333333333",
+  teamId: "22222222-2222-4222-8222-222222222222",
+  userId: "11111111-1111-4111-8111-111111111111",
+  type: "shelly_question",
+  subjectId: "question-1",
+  workflowId: "44444444-4444-4444-8444-444444444444",
+  title: "Which source should be used?",
+  payload: { sessionId: "session-1", futureKey: "preserved" },
+  isRead: false,
+  readAt: null,
+  deletedAt: null,
+  createdAt: "2026-08-05T10:00:00.000Z",
+  updatedAt: "2026-08-05T10:00:00.000Z",
+};
+
+function listResponse(items: Array<Record<string, unknown>>, unreadCount = 1) {
+  return {
+    data: {
+      data: { unreadCount, items },
+      status: "success",
+    },
+  };
+}
+
+describe("InboxService", () => {
+  beforeEach(() => {
+    mockList.mockReset();
+    mockMarkRead.mockReset();
+  });
+
+  test("exports the curated Inbox contract from the package root", () => {
+    const type: InboxItemTypeValue = InboxItemType.AssistantQuestion;
+    const item = { type } as InboxItem;
+    const list = { unreadCount: 0, items: [item] } as InboxListResult;
+    const mutation: InboxMarkReadResult = { readCount: 0 };
+
+    expect(list.items[0]?.type).toBe("shelly_question");
+    expect(mutation.readCount).toBe(0);
+  });
+
+  test("lists curated personal Inbox items", async () => {
+    mockList.mockResolvedValueOnce(listResponse([baseItem]));
+
+    const result = await createTestClient().inbox.list();
+
+    expect(mockList).toHaveBeenCalledWith();
+    expect(result).toEqual({
+      unreadCount: 1,
+      items: [
+        {
+          id: baseItem.id,
+          type: "shelly_question",
+          subjectId: "question-1",
+          workflowId: baseItem.workflowId,
+          title: "Which source should be used?",
+          payload: { sessionId: "session-1", futureKey: "preserved" },
+          isRead: false,
+          readAt: null,
+          createdAt: "2026-08-05T10:00:00.000Z",
+          updatedAt: "2026-08-05T10:00:00.000Z",
+        },
+      ],
+    });
+    expect(result.items[0]).not.toHaveProperty("teamId");
+    expect(result.items[0]).not.toHaveProperty("userId");
+    expect(result.items[0]).not.toHaveProperty("deletedAt");
+  });
+
+  test("preserves every known item type and nullable fields", async () => {
+    mockList.mockResolvedValueOnce(
+      listResponse(
+        [
+          { ...baseItem, type: "shelly_question" },
+          {
+            ...baseItem,
+            id: "55555555-5555-4555-8555-555555555555",
+            type: "data_quality_issues",
+            workflowId: null,
+            readAt: "2026-08-05T11:00:00.000Z",
+          },
+          {
+            ...baseItem,
+            id: "66666666-6666-4666-8666-666666666666",
+            type: "sample_data_ready",
+          },
+        ],
+        2,
+      ),
+    );
+
+    const result = await createTestClient().inbox.list();
+
+    expect(result.items.map((item) => item.type)).toEqual([
+      "shelly_question",
+      "data_quality_issues",
+      "sample_data_ready",
+    ]);
+    expect(result.items[1]?.workflowId).toBeNull();
+    expect(result.items[1]?.readAt).toBe("2026-08-05T11:00:00.000Z");
+  });
+
+  test("passes through future item types and payload keys", async () => {
+    mockList.mockResolvedValueOnce(
+      listResponse([
+        {
+          ...baseItem,
+          type: "future_attention_item",
+          payload: { futureShape: { nested: true } },
+        },
+      ]),
+    );
+
+    const result = await createTestClient().inbox.list();
+
+    expect(result.items[0]?.type).toBe("future_attention_item");
+    expect(result.items[0]?.payload).toEqual({
+      futureShape: { nested: true },
+    });
+  });
+
+  test.each([
+    1, 0,
+  ])("marks one item read and returns readCount=%i", async (readCount) => {
+    mockMarkRead.mockResolvedValueOnce({
+      data: { data: { readCount }, status: "success" },
+    });
+    const itemId = "33333333-3333-4333-8333-333333333333";
+
+    const result = await createTestClient().inbox.markRead(itemId);
+
+    expect(mockMarkRead).toHaveBeenCalledWith({ itemId });
+    expect(result).toEqual({ readCount });
+  });
+
+  test("propagates generated API errors", async () => {
+    mockList.mockRejectedValueOnce(new Error("Inbox unavailable"));
+
+    await expect(createTestClient().inbox.list()).rejects.toThrow(
+      "Inbox unavailable",
+    );
+  });
+});

--- a/sdks/node/test/unit/openapi-spec.test.ts
+++ b/sdks/node/test/unit/openapi-spec.test.ts
@@ -18,4 +18,13 @@ describe("published OpenAPI source", () => {
       spec.paths["/v5/agent/workflows/{workflowId}/timeline"].get.operationId,
     ).toBe("v5AgentWorkflowAssistantTimeline");
   });
+
+  test("includes the personal Inbox operations", () => {
+    const spec = JSON.parse(readFileSync(specPath, "utf8"));
+
+    expect(spec.paths["/v5/inbox"].get.operationId).toBe("v5InboxList");
+    expect(spec.paths["/v5/inbox/{itemId}/mark-read"].post.operationId).toBe(
+      "v5InboxMarkRead",
+    );
+  });
 });

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -7074,6 +7074,16 @@
               }
             }
           },
+          "400": {
+            "description": "The active team or Inbox query is invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxErrorResponse"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Authentication failed or no active team is selected",
             "content": {
@@ -7099,7 +7109,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InboxDependencyUnavailableResponse"
+                  "$ref": "#/components/schemas/InboxSimpleErrorResponse"
                 }
               }
             }
@@ -7188,7 +7198,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InboxDependencyUnavailableResponse"
+                  "$ref": "#/components/schemas/InboxSimpleErrorResponse"
                 }
               }
             }
@@ -22057,7 +22067,7 @@
           }
         }
       },
-      "InboxErrorResponse": {
+      "InboxStructuredErrorResponse": {
         "type": "object",
         "required": [
           "data",
@@ -22079,7 +22089,7 @@
           }
         }
       },
-      "InboxDependencyUnavailableResponse": {
+      "InboxSimpleErrorResponse": {
         "type": "object",
         "required": [
           "error"
@@ -22089,6 +22099,16 @@
             "type": "string"
           }
         }
+      },
+      "InboxErrorResponse": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/InboxStructuredErrorResponse"
+          },
+          {
+            "$ref": "#/components/schemas/InboxSimpleErrorResponse"
+          }
+        ]
       },
       "EmailChannelConfig": {
         "type": "object",

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -7050,6 +7050,152 @@
         }
       }
     },
+    "/v5/inbox": {
+      "get": {
+        "operationId": "v5InboxList",
+        "summary": "List personal Inbox items",
+        "description": "Returns all Inbox items visible to the authenticated user in the active team, with unread items first.",
+        "tags": [
+          "Inbox"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Inbox items returned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or no active team is selected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Inbox items could not be listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Inbox storage is temporarily unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxDependencyUnavailableResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v5/inbox/{itemId}/mark-read": {
+      "post": {
+        "operationId": "v5InboxMarkRead",
+        "summary": "Mark one personal Inbox item as read",
+        "description": "Acknowledges one Inbox item for the authenticated user in the active team without performing the item's underlying workflow action.",
+        "tags": [
+          "Inbox"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "itemId",
+            "in": "path",
+            "required": true,
+            "description": "Inbox item ID",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Inbox item acknowledgment completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxReadMutationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid Inbox item ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or no active team is selected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The active role cannot mutate Inbox read state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Inbox item could not be marked as read",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Inbox storage is temporarily unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxDependencyUnavailableResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v5/notifications/channels": {
       "get": {
         "summary": "Retrieve all notification channels",
@@ -8778,7 +8924,7 @@
                     },
                     "scheduledWorkflows": {
                       "type": "integer",
-                      "description": "ACTIVE workflows with an active schedule (auto-run, roll over to next cycle)"
+                      "description": "ACTIVE workflows with an active schedule OR on a live real-time monitor lane (REAL_TIME, SHELLY_REAL_TIME_SCRIPT) — both auto-run and roll over to the next cycle"
                     },
                     "workflows": {
                       "type": "array",
@@ -8799,7 +8945,7 @@
                           },
                           "scheduled": {
                             "type": "boolean",
-                            "description": "ACTIVE and on an active schedule (recurring); else completed/one-off"
+                            "description": "ACTIVE and either on an active schedule or a live real-time monitor (recurring); else completed/one-off"
                           },
                           "firstRunAt": {
                             "type": "string",
@@ -14653,12 +14799,13 @@
                     "type": "string",
                     "enum": [
                       "auto",
+                      "direct",
                       "dc",
                       "isp",
                       "residential",
                       "stealth"
                     ],
-                    "description": "Proxy tier: auto (smart selection), dc (datacenter), isp, residential, or stealth to route through the anti-bot providers for sites that block bots. Stealth providers use their own egress and pricing. Default: auto"
+                    "description": "Proxy tier: auto (smart selection), direct (Squid server egress without location guarantees), dc (datacenter), isp, residential, or stealth to route through the anti-bot providers for sites that block bots. Stealth providers use their own egress and pricing. Default: auto"
                   },
                   "format": {
                     "default": "html",
@@ -15132,11 +15279,12 @@
                               "proxy": {
                                 "type": "string",
                                 "enum": [
+                                  "direct",
                                   "dc",
                                   "isp",
                                   "residential"
                                 ],
-                                "description": "Proxy type: datacenter, ISP, or residential",
+                                "description": "Proxy type: direct Squid egress, datacenter, ISP, or residential",
                                 "nullable": true
                               },
                               "location": {
@@ -21765,6 +21913,183 @@
           }
         }
       },
+      "InboxItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "teamId",
+          "userId",
+          "type",
+          "subjectId",
+          "workflowId",
+          "title",
+          "payload",
+          "isRead",
+          "readAt",
+          "deletedAt",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "teamId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "shelly_question",
+              "data_quality_issues",
+              "sample_data_ready"
+            ]
+          },
+          "subjectId": {
+            "type": "string"
+          },
+          "workflowId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "title": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "isRead": {
+            "type": "boolean"
+          },
+          "readAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "deletedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "InboxListData": {
+        "type": "object",
+        "required": [
+          "unreadCount",
+          "items"
+        ],
+        "properties": {
+          "unreadCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InboxItem"
+            }
+          }
+        }
+      },
+      "InboxListResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/InboxListData"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          }
+        }
+      },
+      "InboxReadMutationData": {
+        "type": "object",
+        "required": [
+          "readCount"
+        ],
+        "properties": {
+          "readCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 1
+          }
+        }
+      },
+      "InboxReadMutationResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/InboxReadMutationData"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ]
+          }
+        }
+      },
+      "InboxErrorResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "status",
+          "message"
+        ],
+        "properties": {
+          "data": {
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "InboxDependencyUnavailableResponse": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        }
+      },
       "EmailChannelConfig": {
         "type": "object",
         "required": [
@@ -23351,6 +23676,7 @@
                 "type": "string",
                 "enum": [
                   "auto",
+                  "direct",
                   "dc",
                   "resi",
                   "isp"
@@ -23711,6 +24037,7 @@
                 "type": "string",
                 "enum": [
                   "auto",
+                  "direct",
                   "dc",
                   "resi",
                   "isp"
@@ -24088,6 +24415,7 @@
                 "type": "string",
                 "enum": [
                   "auto",
+                  "direct",
                   "dc",
                   "resi",
                   "isp"
@@ -24498,6 +24826,7 @@
                 "type": "string",
                 "enum": [
                   "auto",
+                  "direct",
                   "dc",
                   "resi",
                   "isp"


### PR DESCRIPTION
## Summary
- add a first-class `client.inbox` Node SDK domain
- expose `list()` and `markRead(itemId)` through generated `InboxApi` operations
- curate personal Inbox items by dropping redundant `teamId`, `userId`, and `deletedAt` fields
- preserve nullable fields, payload keys, future runtime item types, and zero/one acknowledgment counts
- refresh the committed OpenAPI source from the backend contract

## Contract
```ts
client.inbox.list(): Promise<InboxListResult>
client.inbox.markRead(itemId): Promise<InboxMarkReadResult>
```

The spec refresh also includes already-landed backend proxy enum/description drift present in the generated backend artifact.

## Validation
- Node SDK unit tests: 148 passed
- Node SDK typecheck
- Node SDK build
- Biome check for all changed SDK files

Repository-wide Biome currently remains red on existing configuration/version and unrelated legacy diagnostics; no changed Inbox file has a Biome finding. Live E2E tests were not run because they require API credentials.

Depends on kadoa-org/kadoa-backend#10948.

Linear: KAD-18811


BEGIN_COMMIT_OVERRIDE
feat(node-sdk): expose personal Inbox
END_COMMIT_OVERRIDE
