### PR TITLE
docs: cover Assistant and Inbox SDK workflows

### DIFF
--- a/docs/SDK_API_REFERENCE.md
+++ b/docs/SDK_API_REFERENCE.md
@@ -1,19 +1,20 @@
 # SDK API Reference
 
-API parity reference for Node and Python SDKs.
+Availability reference for the Node.js and Python SDKs. Method tables identify APIs that are SDK-specific; do not assume blanket parity.
 
-> Node.js SDK is the master SDK. Python SDK maintains feature parity with Node.
+For product behavior and HTTP endpoint details, use the canonical [Kadoa documentation](https://docs.kadoa.com) and [API reference](https://docs.kadoa.com/api-reference/introduction).
 
 ## Overview
-
-Both SDKs provide the same domain structure and API surface:
 
 | Module | Node SDK | Python SDK |
 |--------|----------|------------|
 | Client | `KadoaClient` | `KadoaClient` |
 | Extraction | `ExtractionService`, `ExtractionBuilderService` | `ExtractionModule`, `ExtractionBuilderService` |
 | Schemas | `SchemasService`, `SchemaBuilder` | `SchemasService`, `SchemaBuilder` |
-| Workflows | `WorkflowsCoreService` | `WorkflowsCoreService` |
+| Workflows | `WorkflowsCoreService`; includes `listWorkflowRuns()` | `WorkflowsCoreService`; no `list_workflow_runs()` |
+| Templates | `TemplatesService` | `TemplatesService` |
+| Workflow Assistant | `AssistantService` | Not available |
+| Personal Inbox | `InboxService` | Not available |
 | Notifications | 3 services + `NotificationDomain` | 3 services + `NotificationDomain` |
 | Validation | 2 services + `ValidationDomain` | 2 services + `ValidationDomain` |
 | Realtime | `Realtime` class | `Realtime` class |
@@ -113,6 +114,7 @@ Type validation for field examples:
 | Method | Node | Python |
 |--------|------|--------|
 | Create workflow | `create()` | `create()` |
+| List run history | `listWorkflowRuns()` | Not available |
 | Get workflow | `get()` | `get()` |
 | List workflows | `list()` | `list()` |
 | Get by name | `getByName()` | `get_by_name()` |
@@ -124,7 +126,31 @@ Type validation for field examples:
 | Get job status | `getJobStatus()` | `get_job_status()` |
 | Wait for job | `waitForJobCompletion()` | `wait_for_job_completion()` |
 
-## 5. Notifications Domain
+### Template-specific workflow instructions
+
+Both SDKs can create a workflow from a published template. The template owns `entity`, fields, schema, and monitoring configuration; do not provide those inputs when using a template.
+
+| Input | Node | Python |
+|-------|------|--------|
+| Template ID | `templateId` | `template_id` |
+| Template version (optional) | `templateVersion` | `template_version` |
+| Workflow-specific template instructions (optional) | `userPrompt` | `user_prompt` |
+
+`urls` is required for template creation. If no version is supplied, the API resolves the latest published template version.
+
+### Run history (Node.js only)
+
+`client.workflow.listWorkflowRuns(workflowId, { page, limit, status })` returns paginated run history. `status` accepts `success`, `failed`, or `in_progress`. The Python SDK does not expose this helper.
+
+## 5. Workflow Assistant (Node.js only)
+
+`client.assistant` is available only in the Node.js SDK. Use `createRealtimeWorkflow({ instructions, notificationChannelIds, tags?, newSessionId? })` to create a realtime workflow. For existing workflows, use `requestWorkflowUpdate(workflowId, { instructions, threadId? })` and `getTimeline(workflowId, { cursor?, limit? })`. The service also provides `getPauseState()`, `answerQuestion()`, `getStrategy()`, `interrupt()`, `resume()`, and `stop()`.
+
+## 6. Personal Inbox (Node.js only)
+
+`client.inbox.list()` returns the authenticated user's Inbox items and unread count. `client.inbox.markRead(itemId)` marks one item as read. The Python SDK does not expose an Inbox domain.
+
+## 7. Notifications Domain
 
 ### NotificationChannelsService
 
@@ -163,7 +189,7 @@ Type validation for field examples:
 | Setup for workspace | `setupForWorkspace()` | `setup_for_workspace()` |
 | Test notification | `testNotification()` | `test_notification()` |
 
-## 6. Validation Domain
+## 8. Validation Domain
 
 ### ValidationCoreService
 
@@ -195,7 +221,7 @@ Type validation for field examples:
 | Bulk delete | `bulkDeleteRules()` | `bulk_delete_rules()` |
 | Delete all rules | `deleteAllRules()` | `delete_all_rules()` |
 
-## 7. Realtime
+## 9. Realtime
 
 | Feature | Node | Python |
 |---------|------|--------|
@@ -211,13 +237,13 @@ Type validation for field examples:
 
 **Pattern difference:** Node returns unsubscribe functions from `on*` methods. Python provides explicit `off_*` methods.
 
-## 8. User Service
+## 10. User Service
 
 | Method | Node | Python |
 |--------|------|--------|
 | Get current user | `getCurrentUser()` | `get_current_user()` |
 
-## 9. Exceptions
+## 11. Exceptions
 
 | Feature | Node | Python |
 |---------|------|--------|
@@ -232,7 +258,7 @@ Type validation for field examples:
 | HTTP status mapping | `mapStatusToCode()` | `map_status_to_code()` |
 | From HTTP error | `fromAxiosError()` | `from_api_exception()` |
 
-## 10. Utilities
+## 12. Utilities
 
 | Feature | Node | Python |
 |---------|------|--------|

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -464,6 +464,68 @@ await client.workflow.delete("workflow-id");
 > [!NOTE]
 > `client.workflow.cancel(id)` still calls the delete endpoint for backward compatibility, but it now logs a deprecation warning. Use `client.workflow.delete(id)` going forward.
 
+## Workflow Assistant (Node.js only)
+
+Use the Workflow Assistant to create a realtime workflow from instructions. It requires notification channel IDs that have already been configured for the workspace.
+
+```typescript
+const created = await client.assistant.createRealtimeWorkflow({
+  instructions: 'Monitor product prices and alert me when they change.',
+  notificationChannelIds: ['channel-id'],
+});
+
+console.log(created.workflowId);
+```
+
+For an existing workflow, use `client.assistant.requestWorkflowUpdate(workflowId, { instructions })`. Read the customer-visible conversation with `getTimeline(workflowId)`, and use `getPauseState()`, `answerQuestion()`, `interrupt()`, `resume()`, or `stop()` with the returned session ID when needed. This Assistant domain is not available in the Python SDK.
+
+## Personal Inbox (Node.js only)
+
+Read the authenticated user's Inbox and mark an item as read:
+
+```typescript
+const inbox = await client.inbox.list();
+console.log(`${inbox.unreadCount} unread items`);
+
+if (inbox.items[0]) {
+  await client.inbox.markRead(inbox.items[0].id);
+}
+```
+
+Inbox access is scoped to the authenticated user and is not available in the Python SDK.
+
+## Workflow Run History (Node.js only)
+
+Retrieve a workflow's paginated run history. Optionally filter by `success`, `failed`, or `in_progress`.
+
+```typescript
+const history = await client.workflow.listWorkflowRuns('workflow-id', {
+  page: 1,
+  limit: 20,
+  status: 'success',
+});
+
+console.log(history);
+```
+
+## Create a Workflow from a Template
+
+Create a workflow from a published template with `templateId`. `urls` is required; `templateVersion` selects a published version when needed. `userPrompt` is optional and adds workflow-specific instructions to the template prompt. Do not supply `entity`, `fields`, `schemaId`, or `monitoring`, because the template controls them.
+
+```typescript
+const workflow = await client.workflow.create({
+  urls: ['https://example.com/products'],
+  templateId: 'template-id',
+  templateVersion: 2,
+  userPrompt: 'Only include products currently in stock.',
+  name: 'In-stock products',
+});
+
+console.log(workflow.id);
+```
+
+For template lifecycle semantics, see [Create Workflows from Templates](https://docs.kadoa.com/docs/sdk/templates/overview).
+
 ## Requirements
 
 - Node.js 22+

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -45,6 +45,30 @@ print(f"Extracted {len(result.data)} items")
 
 That's it! With the SDK, data is automatically extracted. For more control, specify exactly what fields you want using the builder API.
 
+## Create a Workflow from a Template
+
+Instantiate a workflow from a published template with `template_id`. `urls` is required; `template_version` optionally selects a published version. `user_prompt` adds workflow-specific instructions to the template prompt. Do not supply `entity`, `fields`, `schema_id`, or `monitoring`, because the template controls them.
+
+```python
+from kadoa_sdk.workflows.workflows_core_service import CreateWorkflowInput
+
+workflow = client.workflow.create(
+    CreateWorkflowInput(
+        urls=['https://example.com/products'],
+        template_id='11111111-1111-4111-8111-111111111111',
+        template_version=2,
+        user_prompt='Only include products currently in stock.',
+        name='In-stock products',
+    )
+)
+
+print(workflow.id)
+```
+
+## Node.js-only APIs
+
+Workflow Assistant, personal Inbox, and `listWorkflowRuns` are currently available only in the [Node.js SDK](https://www.npmjs.com/package/@kadoa/node-sdk). They are not exposed by this Python SDK. See [Create Workflows from Templates](https://docs.kadoa.com/docs/sdk/templates/overview) for template lifecycle semantics.
+
 ## Realtime WebSockets
 
 ```python


### PR DESCRIPTION
## Summary
- Add Node and Python SDK README guidance for Assistant/realtime, Inbox, run history, template-specific instructions, and notifications.
- Align the SDK API reference availability matrix with currently supported SDK surfaces.
- Keep canonical lifecycle guidance in the public documentation: https://github.com/kadoa-org/kadoa-backend/pull/11153

## Validation
- `git diff --check`
- Source-consistency review against the current backend, SDK, and MCP implementations

No SDK runtime behavior, generated code, or release configuration changed. `bun install --frozen-lockfile` could not run because this worktree has pre-existing Bun lockfile drift; no lockfile was changed.